### PR TITLE
Feature/pip compile script

### DIFF
--- a/scripts/pip-compile.sh
+++ b/scripts/pip-compile.sh
@@ -39,6 +39,11 @@ do
     esac
 done
 
+if [[ ! -f ${MODULE_PATH}/requirements.in ]]; then
+    echo "No requirements.in found in ${MODULE_PATH}"
+    exit 1
+fi
+
 VENV_PATH="${DIR}/venv-$(date +%s)"
 deactivate || echo "No active virtualenv"
 python3 -m venv ${VENV_PATH}

--- a/scripts/pip-compile.sh
+++ b/scripts/pip-compile.sh
@@ -1,0 +1,57 @@
+#!/usr/bin/env bash
+#
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+#   Licensed under the Apache License, Version 2.0 (the "License").
+#   You may not use this file except in compliance with the License.
+#   You may obtain a copy of the License at
+#
+#       http://www.apache.org/licenses/LICENSE-2.0
+#
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#   limitations under the License.
+#
+
+set -e
+
+DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )/.." >/dev/null 2>&1 && pwd )"
+
+while [ $# -gt 0 ]
+do
+    case $1 in
+        --path)
+        MODULE_PATH="${DIR}/${2}"
+        shift # Remove --path from processing
+        shift # Remove $2 from processing
+        ;;
+        -*|--*)
+        echo "Unknown option $1"
+        exit 1
+        ;;
+    esac
+done
+
+VENV_PATH="${DIR}/venv-$(date +%s)"
+python3 -m venv ${VENV_PATH}
+. ${VENV_PATH}/bin/activate
+echo "Created and activated virtualenv at ${VENV_PATH}"
+
+echo "Installing dependencies from requirements.txt and requirements-dev.txt"
+pip install -r ${DIR}/requirements.txt
+pip install -r ${DIR}/requirements-dev.txt
+
+echo "Module Path: ${MODULE_PATH}"
+pushd ${MODULE_PATH}
+
+if [[ -f requirements.in ]]; then
+    echo "Found requirements.in"
+    pip-compile requirements.in
+fi
+
+echo "Deactivating and removing virtualenv"
+popd
+deactivate
+rm -fr ${VENV_PATH}

--- a/scripts/pip-compile.sh
+++ b/scripts/pip-compile.sh
@@ -40,6 +40,7 @@ do
 done
 
 VENV_PATH="${DIR}/venv-$(date +%s)"
+deactivate || echo "No active virtualenv"
 python3 -m venv ${VENV_PATH}
 . ${VENV_PATH}/bin/activate
 echo "Created and activated virtualenv at ${VENV_PATH}"

--- a/scripts/pip-compile.sh
+++ b/scripts/pip-compile.sh
@@ -18,6 +18,7 @@
 set -e
 
 DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )/.." >/dev/null 2>&1 && pwd )"
+UPGRADE=""
 
 while [ $# -gt 0 ]
 do
@@ -26,6 +27,10 @@ do
         MODULE_PATH="${DIR}/${2}"
         shift # Remove --path from processing
         shift # Remove $2 from processing
+        ;;
+        --upgrade)
+        UPGRADE="--upgrade"
+        shift # Remove --upgrade from processing
         ;;
         -*|--*)
         echo "Unknown option $1"
@@ -48,7 +53,7 @@ pushd ${MODULE_PATH}
 
 if [[ -f requirements.in ]]; then
     echo "Found requirements.in"
-    pip-compile requirements.in
+    pip-compile ${UPGRADE} requirements.in
 fi
 
 echo "Deactivating and removing virtualenv"


### PR DESCRIPTION
*Issue #, if available:* None

*Description of changes:* Added script to simplify locking python dependencies. Script should be executed from root of the project:

```
scripts/pip-compile.sh --path modules/core/eks
```

Also supports upgrading requirements:
```
scripts/pip-compile.sh --path modules/core/eks --upgrade
```


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
