### PR TITLE
correct conversion to NagPackSuppression

### DIFF
--- a/modules/analysis/aws-batch-demo/stack.py
+++ b/modules/analysis/aws-batch-demo/stack.py
@@ -160,14 +160,12 @@ class AwsBatchPipeline(Stack):
                     **{
                         "id": "AwsSolutions-IAM4",
                         "reason": "Managed Policies are for service account roles only",
-                        "applies_to": "*",
                     }
                 ),
                 NagPackSuppression(
                     **{
                         "id": "AwsSolutions-IAM5",
                         "reason": "Resource access restriced to ADDF resources",
-                        "applies_to": "*",
                     }
                 ),
             ],

--- a/modules/analysis/rosbag-image-pipeline/stack.py
+++ b/modules/analysis/rosbag-image-pipeline/stack.py
@@ -163,14 +163,12 @@ class AwsBatchPipeline(Stack):
                     **{
                         "id": "AwsSolutions-IAM4",
                         "reason": "Managed Policies are for service account roles only",
-                        "applies_to": "*",
                     }
                 ),
                 NagPackSuppression(
                     **{
                         "id": "AwsSolutions-IAM5",
                         "reason": "Resource access restriced to ADDF resources",
-                        "applies_to": "*",
                     }
                 ),
             ],

--- a/modules/core/aws-batch/stack.py
+++ b/modules/core/aws-batch/stack.py
@@ -233,14 +233,12 @@ class AwsBatch(Stack):
                     **{
                         "id": "AwsSolutions-IAM4",
                         "reason": "Managed Policies are for service account roles only",
-                        "applies_to": "*",
                     }
                 ),
                 NagPackSuppression(
                     **{
                         "id": "AwsSolutions-IAM5",
                         "reason": "Resource access restriced to ADDF resources",
-                        "applies_to": "*",
                     }
                 ),
             ],

--- a/modules/core/mwaa/stack.py
+++ b/modules/core/mwaa/stack.py
@@ -277,28 +277,24 @@ class MWAAStack(Stack):  # type: ignore
                 **{
                     "id": "AwsSolutions-S1",
                     "reason": "Logs are disabled for demo purposes",
-                    "applies_to": "*",
                 }
             ),
             NagPackSuppression(
                 **{
                     "id": "AwsSolutions-S5",
                     "reason": "No OAI needed - no one is accessing this data without explicit permissions",
-                    "applies_to": "*",
                 }
             ),
             NagPackSuppression(
                 **{
                     "id": "AwsSolutions-IAM5",
                     "reason": "Resource access restriced to ADDF resources",
-                    "applies_to": "*",
                 }
             ),
             NagPackSuppression(
                 **{
                     "id": "AwsSolutions-IAM4",
                     "reason": "Managed Policies are for service account roles only",
-                    "applies_to": "*",
                 }
             ),
         ]

--- a/modules/core/neptune/stack.py
+++ b/modules/core/neptune/stack.py
@@ -129,14 +129,12 @@ class NeptuneStack(Stack):
                     **{
                         "id": "AwsSolutions-N5",
                         "reason": "Cluster is in private subnets, no DB IAM auth enabled",
-                        "applies_to": "*",
                     }
                 ),
                 NagPackSuppression(
                     **{
                         "id": "AwsSolutions-EC23",
                         "reason": "Cluster is in private subnets, open to all available IP within VPC",
-                        "applies_to": "*",
                     }
                 ),
             ],

--- a/modules/core/opensearch/stack.py
+++ b/modules/core/opensearch/stack.py
@@ -123,56 +123,48 @@ class OpenSearchStack(Stack):  # type: ignore
                     **{
                         "id": "AwsSolutions-OS2",
                         "reason": "Node to Node encryption not enabled - no customer data",
-                        "applies_to": "*",
                     }
                 ),
                 NagPackSuppression(
                     **{
                         "id": "AwsSolutions-OS3",
                         "reason": "Access restricted by security group ingress permissions in VPC",
-                        "applies_to": "*",
                     }
                 ),
                 NagPackSuppression(
                     **{
                         "id": "AwsSolutions-OS4",
                         "reason": "Single noe for demo purposes",
-                        "applies_to": "*",
                     }
                 ),
                 NagPackSuppression(
                     **{
                         "id": "AwsSolutions-OS5",
                         "reason": "Access restricted by security group ingress permissions in VPC",
-                        "applies_to": "*",
                     }
                 ),
                 NagPackSuppression(
                     **{
                         "id": "AwsSolutions-OS7",
                         "reason": "Single Node for Demo purposes",
-                        "applies_to": "*",
                     }
                 ),
                 NagPackSuppression(
                     **{
                         "id": "AwsSolutions-OS8",
                         "reason": "No customer data - for Demo purposes",
-                        "applies_to": "*",
                     }
                 ),
                 NagPackSuppression(
                     **{
                         "id": "AwsSolutions-OS9",
                         "reason": "No logs - for Demo purposes",
-                        "applies_to": "*",
                     }
                 ),
                 NagPackSuppression(
                     **{
                         "id": "AwsSolutions-IAM4",
                         "reason": "Managed policies used by service accout roles and managed service",
-                        "applies_to": "*",
                     }
                 ),
             ],

--- a/modules/integration/ddb-to-opensearch/stack.py
+++ b/modules/integration/ddb-to-opensearch/stack.py
@@ -163,14 +163,12 @@ class DDBtoOpensearch(Stack):
                     **{
                         "id": "AwsSolutions-IAM4",
                         "reason": "Managed Policies are for service account roles only",
-                        "applies_to": "*",
                     }
                 ),
                 NagPackSuppression(
                     **{
                         "id": "AwsSolutions-IAM5",
                         "reason": "Resource access restriced to ADDF resources",
-                        "applies_to": "*",
                     }
                 ),
             ],

--- a/modules/integration/eks-to-opensearch/stack.py
+++ b/modules/integration/eks-to-opensearch/stack.py
@@ -121,14 +121,12 @@ class EksOpenSearchIntegrationStack(Stack):
                     **{
                         "id": "AwsSolutions-IAM4",
                         "reason": "Managed Policies are for service account roles only",
-                        "applies_to": "*",
                     }
                 ),
                 NagPackSuppression(
                     **{
                         "id": "AwsSolutions-IAM5",
                         "reason": "Resource access restriced to ADDF resources",
-                        "applies_to": "*",
                     }
                 ),
             ],

--- a/modules/optionals/datalake-buckets/stack.py
+++ b/modules/optionals/datalake-buckets/stack.py
@@ -222,14 +222,12 @@ class DataLakeBucketsStack(Stack):  # type: ignore
                 **{
                     "id": "AwsSolutions-S1",
                     "reason": "Logging has been disabled for demo purposes",
-                    "applies_to": "*",
                 }
             ),
             NagPackSuppression(
                 **{
                     "id": "AwsSolutions-IAM5",
                     "reason": "Resource access restriced to ADDF resources",
-                    "applies_to": "*",
                 }
             ),
         ]

--- a/modules/simulations/k8s-managed/stack.py
+++ b/modules/simulations/k8s-managed/stack.py
@@ -185,14 +185,12 @@ class SimulationDags(Stack):
                     **{
                         "id": "AwsSolutions-IAM4",
                         "reason": "Managed Policies are for service account roles only",
-                        "applies_to": "*",
                     }
                 ),
                 NagPackSuppression(
                     **{
                         "id": "AwsSolutions-IAM5",
                         "reason": "Resource access restriced to ADDF resources",
-                        "applies_to": "*",
                     }
                 ),
             ],


### PR DESCRIPTION
When updating some stacks to NagPackSuppression, the `applies_to = "*"` on the rule suppression was no longer valid...causing errors
