### PR TITLE
aligning resource permisssion

### DIFF
--- a/modules/core/aws-batch/modulestack.yaml
+++ b/modules/core/aws-batch/modulestack.yaml
@@ -2,12 +2,12 @@ AWSTemplateFormatVersion: 2010-09-09
 Description: This template deploys a Module specific IAM permissions
 
 Parameters:
-  DeploymentName:
-    Type: String
-    Description: The name of the deployment
-  ModuleName:
-    Type: String
-    Description: The name of the Module
+  # DeploymentName:
+  #   Type: String
+  #   Description: The name of the deployment
+  # ModuleName:
+  #   Type: String
+  #   Description: The name of the Module
   RoleName:
     Type: String
     Description: The name of the IAM Role

--- a/modules/core/aws-batch/modulestack.yaml
+++ b/modules/core/aws-batch/modulestack.yaml
@@ -30,7 +30,7 @@ Resources:
               - "iam:CreateServiceLinkedRole"
             Effect: Allow
             Resource:
-               - !Sub 'arn:aws:iam::${AWS::AccountId}:role/addf-${DeploymentName}-${ModuleName}-masterrole'
+               - !Sub "arn:aws:iam::${AWS::AccountId}:role/aws-service-role/*.amazonaws.com/*"
         Version: 2012-10-17
       PolicyName: addf-modulespecific-policy
       Roles: [!Ref RoleName]


### PR DESCRIPTION
The resource permissions on the modulestack do not seem to make sense when creating a service-linked role in the modulestack.yaml.  This policy allow the deployspec to have the permissions it needs.  No where did it refer to the role `*-masterrole` needing a service linked role creation.  

I corrected the resource reference
