### PR TITLE
fix default account resolution in manifests to reduce confusion

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### **Added**
 
 ### **Changed**
-
+- Updated default accountId resolution in sample manifests to simple key:value mapping to reduce confusion
 ### **Removed**
 
 ## [V1.0.0] - [09/27/2022]

--- a/manifests/aws-batch-demo/deployment.yaml
+++ b/manifests/aws-batch-demo/deployment.yaml
@@ -9,9 +9,7 @@ groups:
     path: manifests/aws-batch-demo/analysis-modules.yaml
 targetAccountMappings:
   - alias: primary
-    accountId:
-      valueFrom:
-        envVariable: 1234567890
+    accountId: 1234567890
     default: true
     parametersGlobal:
       dockerCredentialsSecret: aws-addf-docker-credentials

--- a/manifests/example-dev/deployment.yaml
+++ b/manifests/example-dev/deployment.yaml
@@ -17,9 +17,7 @@ groups:
   #   path: manifests/example-dev/ide-modules.yaml
 targetAccountMappings:
   - alias: primary
-    accountId:
-      valueFrom:
-        envVariable: 1234567890
+    accountId: 1234567890
     default: true
     parametersGlobal:
       dockerCredentialsSecret: aws-addf-docker-credentials

--- a/manifests/example-prod/deployment.yaml
+++ b/manifests/example-prod/deployment.yaml
@@ -17,9 +17,7 @@ groups:
   #   path: manifests/example-prod/ide-modules.yaml
 targetAccountMappings:
   - alias: primary
-    accountId:
-      valueFrom:
-        envVariable: 1234567890
+    accountId: 1234567890
     default: true
     parametersGlobal:
       dockerCredentialsSecret: aws-addf-docker-credentials

--- a/manifests/ros-image-demo/deployment.yaml
+++ b/manifests/ros-image-demo/deployment.yaml
@@ -13,9 +13,7 @@ groups:
     path: manifests/ros-image-demo/ford-analysis-modules.yaml
 targetAccountMappings:
   - alias: primary
-    accountId:
-      valueFrom:
-        envVariable: 1234567890
+    accountId: 1234567890
     default: true
     parametersGlobal:
       dockerCredentialsSecret: aws-addf-docker-credentials


### PR DESCRIPTION
*Issue #, if available:*
Currently we use the example 123456790 together with envVariable for specifying the account ID in manifests. Most users don't see that the 123456790 should be an environment variable name and mistakenly just replace the value with their account ID

*Description of changes:*
- Removed the envVar resolution in example manifests and replaced with simple key: value mapping 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
