### PR TITLE
resize images for detection models

### DIFF
--- a/manifests/ros-image-demo/docker-image-modules.yaml
+++ b/manifests/ros-image-demo/docker-image-modules.yaml
@@ -31,6 +31,10 @@ parameters:
     value: 2
   - name: memory-mib
     value: 8192
+  - name: resized-width
+    value: 1280
+  - name: resized-height
+    value: 720
   - name: full-access-policy-arn
     valueFrom:
       moduleMetadata:

--- a/modules/analysis/rosbag-image-pipeline/app.py
+++ b/modules/analysis/rosbag-image-pipeline/app.py
@@ -17,6 +17,7 @@ mwaa_exec_role = os.getenv(_param("MWAA_EXEC_ROLE"))
 full_access_policy = os.getenv(_param("FULL_ACCESS_POLICY_ARN"))
 source_bucket_name = os.getenv(_param("SOURCE_BUCKET"))
 target_bucket_name = os.getenv(_param("INTERMEDIATE_BUCKET"))
+
 on_demand_job_queue = os.getenv(_param("ON_DEMAND_JOB_QUEUE_ARN"))
 spot_job_queue = os.getenv(_param("SPOT_JOB_QUEUE_ARN"))
 fargate_job_queue = os.getenv(_param("FARGATE_JOB_QUEUE_ARN"))

--- a/modules/analysis/rosbag-image-pipeline/image_dags/ros_image_pipeline.py
+++ b/modules/analysis/rosbag-image-pipeline/image_dags/ros_image_pipeline.py
@@ -262,12 +262,12 @@ def sagemaker_yolo_operation(**kwargs):
     image_directory_items = table.query(
         KeyConditionExpression=Key("pk").eq(batch_id),
         Select="SPECIFIC_ATTRIBUTES",
-        ProjectionExpression="raw_image_dirs",
+        ProjectionExpression="resized_image_dirs",
     )["Items"]
 
     image_directories = []
     for item in image_directory_items:
-        image_directories += item["raw_image_dirs"]
+        image_directories += item["resized_image_dirs"]
 
     logger.info(f"Starting object detection job for {len(image_directories)} directories")
 
@@ -340,12 +340,12 @@ def sagemaker_lanedet_operation(**kwargs):
     image_directory_items = table.query(
         KeyConditionExpression=Key("pk").eq(batch_id),
         Select="SPECIFIC_ATTRIBUTES",
-        ProjectionExpression="raw_image_dirs",
+        ProjectionExpression="resized_image_dirs",
     )["Items"]
 
     image_directories = []
     for item in image_directory_items:
-        image_directories += item["raw_image_dirs"]
+        image_directories += item["resized_image_dirs"]
 
     logger.info(f"Starting lane detection job for {len(image_directories)} directories")
 

--- a/modules/sensor-extraction/ros-to-png/app.py
+++ b/modules/sensor-extraction/ros-to-png/app.py
@@ -41,7 +41,7 @@ stack = RosToPngBatchJob(
     memory_limit_mib=memory_limit_mib,
     s3_access_policy=full_access_policy,
     resized_width=resized_width,
-    resized_height=resized_height
+    resized_height=resized_height,
 )
 
 CfnOutput(

--- a/modules/sensor-extraction/ros-to-png/app.py
+++ b/modules/sensor-extraction/ros-to-png/app.py
@@ -17,10 +17,11 @@ retries = int(os.getenv(_param("RETRIES"), 1))
 timeout_seconds = int(os.getenv(_param("TIMEOUT_SECONDS"), 60))
 vcpus = int(os.getenv(_param("VCPUS"), 4))
 memory_limit_mib = int(os.getenv(_param("MEMORY_MIB"), 16384))
+resized_width = int(os.getenv(_param("RESIZED_WIDTH")))
+resized_height = int(os.getenv(_param("RESIZED_HEIGHT")))
 
 if not full_access_policy:
     raise ValueError("S3 Full Access Policy ARN is missing.")
-
 
 app = App()
 
@@ -39,6 +40,8 @@ stack = RosToPngBatchJob(
     vcpus=vcpus,
     memory_limit_mib=memory_limit_mib,
     s3_access_policy=full_access_policy,
+    resized_width=resized_width,
+    resized_height=resized_height
 )
 
 CfnOutput(

--- a/modules/sensor-extraction/ros-to-png/src/main.py
+++ b/modules/sensor-extraction/ros-to-png/src/main.py
@@ -156,8 +156,8 @@ def main(table_name, index, batch_id, bag_path, images_path, topics, encoding, t
     logger.info("encoding: %s", encoding)
     logger.info("target_bucket: %s", target_bucket)
 
-    resized_width = int(os.environ['RESIZE_WIDTH'])
-    resized_height = int(os.environ['RESIZE_HEIGHT'])
+    resized_width = int(os.environ["RESIZE_WIDTH"])
+    resized_height = int(os.environ["RESIZE_HEIGHT"])
     logger.info("resized_width: %s", resized_width)
     logger.info("resized_height: %s", resized_height)
 
@@ -245,7 +245,7 @@ def main(table_name, index, batch_id, bag_path, images_path, topics, encoding, t
         UpdateExpression="SET "
         "image_extraction_status = :status, "
         "raw_image_dirs = :raw_image_dirs, "
-         "resized_image_dirs = :resized_image_dirs, "
+        "resized_image_dirs = :resized_image_dirs, "
         "raw_image_bucket = :raw_image_bucket, "
         "s3_key = :s3_key, "
         "s3_bucket = :s3_bucket,"

--- a/modules/sensor-extraction/ros-to-png/stack.py
+++ b/modules/sensor-extraction/ros-to-png/stack.py
@@ -42,6 +42,8 @@ class RosToPngBatchJob(Stack):
         timeout_seconds: int,
         vcpus: int,
         memory_limit_mib: int,
+        resized_width: int,
+        resized_height: int,
         **kwargs: Any,
     ) -> None:
         super().__init__(
@@ -120,6 +122,8 @@ class RosToPngBatchJob(Stack):
                     "AWS_DEFAULT_REGION": self.region,
                     "AWS_ACCOUNT_ID": self.account,
                     "DEBUG": "true",
+                    "RESIZE_WIDTH": str(resized_width),
+                    "RESIZE_HEIGHT": str(resized_height),
                 },
                 job_role=role,
                 execution_role=role,


### PR DESCRIPTION
*Issue #53*
https://github.com/awslabs/autonomous-driving-data-framework/issues/53

*Description of changes:*
When extracting images, save a resized image of 1280x720, compatible with yolop model, 
Run detection models on resized images instead of raw images.

<img width="530" alt="Screenshot 2022-10-27 at 16 31 34" src="https://user-images.githubusercontent.com/7329459/198315468-e93d2396-f928-43cf-9ce7-c87faf948c78.png">

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
