### PR TITLE
Bug Fix: image extraction naming issue

### DIFF
--- a/modules/sensor-extraction/ros-to-png/src/main.py
+++ b/modules/sensor-extraction/ros-to-png/src/main.py
@@ -286,7 +286,7 @@ def main(table_name, index, batch_id, bag_path, images_path, topics, encoding, t
         "array_index = :index",
         ExpressionAttributeValues={
             ":status": "success",
-            ":raw_image_dirs": uploaded_directories,
+            ":raw_image_dirs": raw_image_dirs,
             ":resized_image_dirs": resized_image_dirs,
             ":raw_image_bucket": target_bucket,
             ":batch_id": batch_id,

--- a/modules/sensor-extraction/ros-to-png/src/main.py
+++ b/modules/sensor-extraction/ros-to-png/src/main.py
@@ -238,8 +238,8 @@ def main(table_name, index, batch_id, bag_path, images_path, topics, encoding, t
     for topic in topics:
         all_files = extract_images(bag_path, topic, resized_width, resized_height, encoding, images_path)
         logger.info(f"Uploading results - {target_bucket}")
-        uploaded_directories = upload(s3, target_bucket, drive_id, file_id, all_files)
-        uploaded_directories += uploaded_directories
+        topic_uploaded_directories = upload(s3, target_bucket, drive_id, file_id, all_files)
+        uploaded_directories += topic_uploaded_directories
         logger.info("Uploaded results")
 
     raw_image_dirs = [d for d in uploaded_directories if "resized" not in d]


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Not all resized image directories are being passed on to the object detection and lane detection jobs. This fixes the root issue.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
