### PR TITLE
Lambda name limit fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,7 +28,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Ros to Png Image Extraction relies on EC2 capacity providers in AWS Batch instead of Fargate
 - Updated default accountId resolution in sample manifests to simple key:value mapping to reduce confusion
 - Updated `seedfarmer` version to 2.2.1 for being able to use `.env` files
-
+- in `modules/analysis/rosbag-scene-detection` limited the length of the name of the `StepFunctionTrigger` 
 ### **Removed**
 
 =======

--- a/modules/analysis/rosbag-scene-detection/infrastructure/ecs_stack.py
+++ b/modules/analysis/rosbag-scene-detection/infrastructure/ecs_stack.py
@@ -306,10 +306,12 @@ class Fargate(aws_cdk.Stack):
 
         state_machine.grant_task_response(ecs_task_role)
 
+        ecsTaskTriggerName = f"addf-{deployment_name}-{module_name}-ecsTaskTrigger"
+        ecsTaskTriggerName = ecsTaskTriggerName[:63]
         lambda_function = aws_lambda.Function(
             self,
             "StepFunctionTrigger",
-            function_name=f"addf-{deployment_name}-{module_name}-ecsTaskTrigger",
+            function_name=ecsTaskTriggerName,
             code=aws_lambda.Code.from_inline(lambda_code),
             environment={
                 "state_machine_arn": state_machine.state_machine_arn,


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
The name of the lambda for `StepFunctionTrigger` in `modules/analysis/rosbag-scene-detection/infrastructure/ecs_stack.py` was hitting the 64 char limit of the service...limiting the overall name.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
