### PR TITLE
fix lambda name length on ecsTriggerName

### DIFF
--- a/modules/analysis/rosbag-scene-detection/infrastructure/ecs_stack.py
+++ b/modules/analysis/rosbag-scene-detection/infrastructure/ecs_stack.py
@@ -305,11 +305,13 @@ class Fargate(aws_cdk.Stack):
         )
 
         state_machine.grant_task_response(ecs_task_role)
-
+        
+        ecsTaskTriggerName = f"addf-{deployment_name}-{module_name}-ecsTaskTrigger"
+        ecsTaskTriggerName = ecsTaskTriggerName[:63]
         lambda_function = aws_lambda.Function(
             self,
             "StepFunctionTrigger",
-            function_name=f"addf-{deployment_name}-{module_name}-ecsTaskTrigger",
+            function_name=ecsTaskTriggerName,
             code=aws_lambda.Code.from_inline(lambda_code),
             environment={
                 "state_machine_arn": state_machine.state_machine_arn,


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Adding surgical fix to name of ecsTriggerName in rosbag-scene-detection:
`modules/analysis/rosbag-scene-detection/infrastructure/ecs_stack.py` -- ref `ecsTaskTriggerName` lines 309, 310, 314

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
