### PR TITLE
allowing successful deployment of users even if users not defined

### DIFF
--- a/manifests/mlops/kf-users.yaml
+++ b/manifests/mlops/kf-users.yaml
@@ -1,7 +1,7 @@
 name: kubeflow-users
 path: modules/mlops/kubeflow-users
-targetAccount: primary
-targetRegion: us-east-1
+#targetAccount: primary
+#targetRegion: us-east-1
 parameters:
   - name: EksClusterAdminRoleArn
     valueFrom:
@@ -30,6 +30,6 @@ parameters:
   # - name: KubeflowUsers
   #   value:
   #   - policyArn: arn:aws:iam::aws:policy/AdministratorAccess
-  #     secret: addf-dataservice-users-kubeflow-users-kf-dgraeber
+  #     secret: addf-mlops-kubeflow-users-user1
   #   - policyArn: arn:aws:iam::aws:policy/AdministratorAccess
-  #     secret: testderekaddf
+  #     secret: addf-mlops-kubeflow-users-user2

--- a/modules/mlops/kubeflow-users/README.md
+++ b/modules/mlops/kubeflow-users/README.md
@@ -101,24 +101,27 @@ None
 
 
 ### Module Metadata Outputs
-- `KubeflowUsersDeployed` - a stringifed dict of the users deployed with the username as the key and the usename, email and AWS SecretsManager names for reference
 - `EksClusterName` - the name of the EKS cluster these users are tied to
-
+- `KubeflowUsers` - a stringifed list of dict's with :
+  - `policyArn` - the policy ARN passed in tied to the newly created IAM role 
+  - `secret` - the name of the AWS SecretsManager name tied to the newly created IAM role  
+  - `roleArn` - the ARN of the the newly created role that the Kubeflow user will have attached to user pods in the user namespace
 #### Output Example
 ```json
 {
-  "KubeflowUsers": {
-    "someuser": {
-      "email": "someuser@amazon.com",
-      "secretname": "addf-dataservice-ml-kubeflow-kf-someuser",
-      "username": "someuser"
+  "EksClusterName": "addf-mlops-core-eks-cluster",
+  "KubeflowUsers": [
+    {
+      "policyArn": "arn:aws:iam::aws:policy/AdministratorAccess",
+      "roleArn": "arn:aws:iam::123456789012:role/addf-mlops-users-kubeflow-users-us-east-1-0",
+      "secret": "addf-mlops-kubeflow-users-user1"
     },
-    "anotheruser": {
-      "email": "another.user@gmail.com",
-      "secretname": "addf-dataservice-ml-kubeflow-kf-anotheruser",
-      "username": "anotheruser"
+    {
+      "policyArn": "arn:aws:iam::aws:policy/AdministratorAccess",
+      "roleArn": "arn:aws:iam::123456789012:role/addf-mlops-users-kubeflow-users-us-east-1-1",
+      "secret": "addf-mlops-kubeflow-users-user2"
     }
-  }
+  ]
 }
 
 ```

--- a/modules/mlops/kubeflow-users/deployspec.yaml
+++ b/modules/mlops/kubeflow-users/deployspec.yaml
@@ -11,22 +11,24 @@ deploy:
     build:
       commands:
       # Export all env params specific to the deployment stuff
-      - export CLUSTER_NAME=${ADDF_PARAMETER_EKS_CLUSTER_NAME}
-      - cdk deploy --require-approval never --progress events --app "python app.py" --outputs-file ./cdk-exports.json
-      - export ADDF_MODULE_METADATA=$(python -c "import json; file=open('cdk-exports.json'); print(json.load(file)['addf-${ADDF_DEPLOYMENT_NAME}-${ADDF_MODULE_NAME}']['metadata'])")
-      # Create the configmap for k8s via kustomize and the secrets
-      - python manage_kustomize_users.py $ADDF_MODULE_METADATA
-      # Assume the EKS role and install
-      - eval $(aws sts assume-role --role-arn ${ADDF_PARAMETER_EKS_CLUSTER_ADMIN_ROLE_ARN} --role-session-name aws-auth-ops | jq -r '.Credentials | "export AWS_ACCESS_KEY_ID=\(.AccessKeyId)\nexport AWS_SECRET_ACCESS_KEY=\(.SecretAccessKey)\nexport AWS_SESSION_TOKEN=\(.SessionToken)\n"')
-      - aws eks update-kubeconfig --name ${CLUSTER_NAME}
-      - kubectl kustomize ./kustomize >> profiles/config-map.yaml 
-      - ls -al profiles/
-      - kubectl apply -f profiles/
-      - sleep 10;
-      - ls -al poddefaults/
-      - kubectl apply -f poddefaults/  
-      - kubectl rollout restart deployment dex -n auth
-      - unset AWS_ACCESS_KEY_ID && unset AWS_SECRET_ACCESS_KEY && unset AWS_SESSION_TOKEN
+      - >
+        if [[ ${ADDF_PARAMETER_KUBEFLOW_USERS} ]]; then
+            cdk deploy --require-approval never --progress events --app "python app.py" --outputs-file ./cdk-exports.json;
+            export ADDF_MODULE_METADATA=$(python -c "import json; file=open('cdk-exports.json'); print(json.load(file)['addf-${ADDF_DEPLOYMENT_NAME}-${ADDF_MODULE_NAME}']['metadata'])");
+            python manage_kustomize_users.py $ADDF_MODULE_METADATA;
+            eval $(aws sts assume-role --role-arn ${ADDF_PARAMETER_EKS_CLUSTER_ADMIN_ROLE_ARN} --role-session-name aws-auth-ops | jq -r '.Credentials | "export AWS_ACCESS_KEY_ID=\(.AccessKeyId)\nexport AWS_SECRET_ACCESS_KEY=\(.SecretAccessKey)\nexport AWS_SESSION_TOKEN=\(.SessionToken)\n"');
+            aws eks update-kubeconfig --name ${ADDF_PARAMETER_EKS_CLUSTER_NAME};
+            kubectl kustomize ./kustomize >> profiles/config-map.yaml;
+            ls -al profiles/;
+            kubectl apply -f profiles/;
+            sleep 10;
+            ls -al poddefaults/;
+            kubectl apply -f poddefaults/; 
+            kubectl rollout restart deployment dex -n auth;
+            unset AWS_ACCESS_KEY_ID && unset AWS_SECRET_ACCESS_KEY && unset AWS_SESSION_TOKEN;
+        else
+            echo "No Kubeflow Users configured....please see the module README regarding the usage of this module";
+        fi;
     post_build:
       commands:
       - echo "Deploy successful"
@@ -36,18 +38,11 @@ destroy:
       commands:
       - npm install -g aws-cdk@2.20.0
       - pip install -r requirements.txt
-      - wget https://github.com/kubernetes-sigs/kustomize/releases/download/kustomize/v3.2.1/kustomize_kustomize.v3.2.1_linux_amd64
-      - chmod +x kustomize_kustomize.v3.2.1_linux_amd64
-      - mv kustomize_kustomize.v3.2.1_linux_amd64 /usr/local/bin/kustomize
-      - kustomize version
     build:
       commands:
-      # Export all env params specific to the deployment stuff
-      # Assuming EKS Admin Role
-      - echo ${ADDF_PARAMETER_EKS_CLUSTER_NAME}
-      - eval $(aws sts assume-role --role-arn ${ADDF_PARAMETER_EKS_CLUSTER_ADMIN_ROLE_ARN} --role-session-name aws-auth-ops | jq -r '.Credentials | "export AWS_ACCESS_KEY_ID=\(.AccessKeyId)\nexport AWS_SECRET_ACCESS_KEY=\(.SecretAccessKey)\nexport AWS_SESSION_TOKEN=\(.SessionToken)\n"')
-      - aws eks update-kubeconfig --name ${ADDF_PARAMETER_EKS_CLUSTER_NAME}
-      - unset AWS_ACCESS_KEY_ID && unset AWS_SECRET_ACCESS_KEY && unset AWS_SESSION_TOKEN
-      - cdk destroy --force --app "python app.py"
+      - >
+        if [[ ${ADDF_PARAMETER_KUBEFLOW_USERS} ]]; then
+          cdk destroy --force --app "python app.py";
+        fi;
 
 build_type: BUILD_GENERAL1_SMALL


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

- Allow users to deploy `kubeflow-users` module even if no KubeflwUsers are configured
- update the README in `kubeflow-users`


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
