### PR TITLE
adding output for refernce on kubeflow-platform module

### DIFF
--- a/modules/mlops/kubeflow-platform/README.md
+++ b/modules/mlops/kubeflow-platform/README.md
@@ -76,6 +76,14 @@ This module depends on an existing EKS cluster and access to EKS Master role (an
 
 
 ### Module Metadata Outputs
-None
+- `EksClusterName` - the name of the EKS cluster this Kubeflow platform is deployed on
+
+#### Output Example
+```json
+{
+  "EksClusterName": "addf-mlops-core-eks-cluster"
+}
+
+```
 
 

--- a/modules/mlops/kubeflow-platform/deployspec.yaml
+++ b/modules/mlops/kubeflow-platform/deployspec.yaml
@@ -39,6 +39,7 @@ deploy:
       - helm repo update
       - helm upgrade -i nvdp nvdp/nvidia-device-plugin --version=${PLUGIN} --namespace nvidia-device-plugin --create-namespace --set-file config.map.config=gpu/nvidia-plugin-configmap.yaml || true
       - unset AWS_ACCESS_KEY_ID && unset AWS_SECRET_ACCESS_KEY && unset AWS_SESSION_TOKEN
+      - export ADDF_MODULE_METADATA="{'EksClusterName':'${ADDF_PARAMETER_EKS_CLUSTER_NAME}'}"
 destroy:
   phases:
     install:


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Adding output to the `kubeflow-platform` module to indicate the cluster it is deployed on

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
