### PR TITLE
Fix connection type ssm

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### **Changed**
 - modified `core/mwaa` to take a parameterized `requirements.txt` file to support various deployments
+- fixed Cloud9 SSM connection type config by creating the underlying resources needed to enable the CDK to deploy
 ### **Removed**
 
 

--- a/modules/workbench/cloud9/deployspec.yaml
+++ b/modules/workbench/cloud9/deployspec.yaml
@@ -6,6 +6,7 @@ deploy:
       - pip install -r requirements.txt
     build:
       commands:
+      - python scripts/pre_deploy.py
       - cdk deploy --require-approval never --progress events --app "python app.py" --outputs-file ./cdk-exports.json
       - export ADDF_MODULE_METADATA=$(python -c "import json; file=open('cdk-exports.json'); print(json.load(file)['addf-${ADDF_DEPLOYMENT_NAME}-${ADDF_MODULE_NAME}']['metadata'])")
       - echo $ADDF_MODULE_METADATA

--- a/modules/workbench/cloud9/modulestack.yaml
+++ b/modules/workbench/cloud9/modulestack.yaml
@@ -27,6 +27,22 @@ Resources:
                 ec2:ResourceTag/Name: !Sub 'aws-cloud9-${InstanceName}-*'
           - Effect: Allow
             Action:
+              - "iam:AddRoleToInstanceProfile"
+              - "iam:CreateInstanceProfile"
+              - "iam:Get*"
+              - "iam:RemoveRoleFromInstanceProfile"
+            Resource: "arn:aws:iam::*:instance-profile/cloud9/AWSCloud9SSMInstanceProfile"
+          - Effect: Allow
+            Action:
+              - "iam:AttachRolePolicy"
+              - "iam:CreateRole"
+              - "iam:DetachRolePolicy"
+              - "iam:Get*"
+              - "iam:PassRole"
+              - "iam:TagRole"
+            Resource: "arn:aws:iam::*:role/service-role/AWSCloud9SSMAccessRole"
+          - Effect: Allow
+            Action:
               - "ssm:GetParametersByPath"
             Resource: "arn:aws:ssm:*::parameter/aws/service/cloud9"
         Version: 2012-10-17

--- a/modules/workbench/cloud9/scripts/pre_deploy.py
+++ b/modules/workbench/cloud9/scripts/pre_deploy.py
@@ -2,6 +2,7 @@ import json
 import logging
 import os
 import time
+from typing import Any, Dict, Tuple
 
 import boto3
 
@@ -14,50 +15,44 @@ iam_client = boto3.client("iam")
 role_name = "AWSCloud9SSMAccessRole"
 instance_profile_name = "AWSCloud9SSMInstanceProfile"
 
-def attach_role_to_instance_profile(instance_profile_name: str, role_name: str):
+
+def attach_role_to_instance_profile(instance_profile_name: str, role_name: str) -> None:
     try:
-        iam_client.add_role_to_instance_profile(
-            InstanceProfileName=instance_profile_name,
-            RoleName=role_name
-        )
+        iam_client.add_role_to_instance_profile(InstanceProfileName=instance_profile_name, RoleName=role_name)
     except Exception as err:
         raise err
+
 
 def check_access_role_exist(role_name: str) -> bool:
     try:
         iam_client.get_role(RoleName=role_name)
         _logger.info(f"Using existing role {role_name}.")
         return True
-    except iam_client.exceptions.NoSuchEntityException as err:
+    except iam_client.exceptions.NoSuchEntityException:
         _logger.warning(f"The role {role_name} does not exist")
         return False
 
-def check_instance_profile_exist(instance_profile_name: str) -> None:
+
+def check_instance_profile_exist(instance_profile_name: str) -> Tuple[bool, Dict[str, Any]]:
     try:
         instance_profile_data = iam_client.get_instance_profile(InstanceProfileName=instance_profile_name)
         _logger.info(f"Using existing instance profile {instance_profile_name}.")
         return (True, instance_profile_data)
-    except iam_client.exceptions.NoSuchEntityException as err:
+    except iam_client.exceptions.NoSuchEntityException:
         _logger.info(f"Instance profile {instance_profile_name} does not exist")
-        return (False, [])
+        return (False, {})
 
-def create_access_role(role_name: str):
+
+def create_access_role(role_name: str) -> None:
     assume_role_policy = {
         "Version": "2012-10-17",
         "Statement": [
-        {
+            {
                 "Effect": "Allow",
-                "Principal": {
-                    "Service": [
-                        "cloud9.amazonaws.com",
-                        "ec2.amazonaws.com"
-                    ]
-                },
-                "Action": [
-                    "sts:AssumeRole"
-                ]
+                "Principal": {"Service": ["cloud9.amazonaws.com", "ec2.amazonaws.com"]},
+                "Action": ["sts:AssumeRole"],
             }
-        ]
+        ],
     }
 
     try:
@@ -70,7 +65,7 @@ def create_access_role(role_name: str):
             Tags=[
                 {"Key": "ADDF_DEPLOYMENT_NAME", "Value": os.getenv("ADDF_DEPLOYMENT_NAME")},
                 {"Key": "ADDF_MODULE_NAME", "Value": os.getenv("ADDF_MODULE_NAME")},
-            ]
+            ],
         )
     except Exception as err:
         raise err
@@ -80,31 +75,34 @@ def create_access_role(role_name: str):
     try:
         _logger.info(f"Attaching policy/AWSCloud9SSMInstanceProfile to {role_name}")
         iam_client.attach_role_policy(
-            RoleName=role_name,
-            PolicyArn="arn:aws:iam::aws:policy/AWSCloud9SSMInstanceProfile"
+            RoleName=role_name, PolicyArn="arn:aws:iam::aws:policy/AWSCloud9SSMInstanceProfile"
         )
     except Exception as err:
         raise err
 
-def create_instance_profile(instance_profile_name: str):
+
+def create_instance_profile(instance_profile_name: str) -> None:
     _logger.info(f"Creating instance profile {instance_profile_name}")
     try:
         iam_client.create_instance_profile(
             InstanceProfileName=instance_profile_name,
             Path="/cloud9/",
         )
-    except iam_client.exceptions.NoSuchEntityException as err:
+    except iam_client.exceptions.NoSuchEntityException:
         _logger.warning(f"The role {role_name} does not exist")
+
 
 if os.getenv("ADDF_PARAMETER_CONNECTION_TYPE") == "CONNECT_SSM":
     if not check_access_role_exist(role_name=role_name):
         create_access_role(role_name=role_name)
 
-    instance_profile_exists, instance_profile_data = check_instance_profile_exist(instance_profile_name=instance_profile_name)
+    instance_profile_exists, instance_profile_data = check_instance_profile_exist(
+        instance_profile_name=instance_profile_name
+    )
     if not instance_profile_exists:
         create_instance_profile(instance_profile_name=instance_profile_name)
     else:
-        for role in instance_profile_data.get("InstanceProfile").get("Roles", []):
+        for role in instance_profile_data.get("InstanceProfile", {}).get("Roles", []):
             if role["RoleName"] == role_name:
                 break
         else:

--- a/modules/workbench/cloud9/scripts/pre_deploy.py
+++ b/modules/workbench/cloud9/scripts/pre_deploy.py
@@ -1,0 +1,118 @@
+import json
+import logging
+import os
+import time
+
+import boto3
+
+LOGGING_FORMAT = "[%(asctime)s][%(filename)-13s:%(lineno)3d] %(message)s"
+logging.basicConfig(level=logging.INFO, format=LOGGING_FORMAT)
+_logger: logging.Logger = logging.getLogger(__name__)
+
+iam_client = boto3.client("iam")
+
+role_name = "AWSCloud9SSMAccessRole"
+instance_profile_name = "AWSCloud9SSMInstanceProfile"
+
+def attach_role_to_instance_profile(instance_profile_name: str, role_name: str): 
+    try:
+        iam_client.add_role_to_instance_profile(
+            InstanceProfileName=instance_profile_name,
+            RoleName=role_name
+        )
+    except Exception as err:
+        raise err
+
+def check_access_role_exist(role_name: str) -> bool:
+    try:
+        iam_client.get_role(RoleName=role_name)
+        _logger.info(f"Using existing role {role_name}.")
+        return True
+        
+    except iam_client.exceptions.NoSuchEntityException as err:
+        _logger.warning(f"The role {role_name} does not exist")
+
+        return False
+
+def check_instance_profile_exist(instance_profile_name: str) -> None:
+    try:
+        instance_profile_data = iam_client.get_instance_profile(InstanceProfileName=instance_profile_name)
+        _logger.info(f"Using existing instance profile {instance_profile_name}.")
+
+        return (True, instance_profile_data)
+
+    except iam_client.exceptions.NoSuchEntityException as err:
+        _logger.info(f"Instance profile {instance_profile_name} does not exist")
+        
+        return (False, [])
+
+def create_access_role(role_name: str):
+    assume_role_policy = {
+        "Version": "2012-10-17",
+        "Statement": [
+           {
+                "Effect": "Allow",
+                "Principal": {
+                    "Service": [
+                        "cloud9.amazonaws.com",
+                        "ec2.amazonaws.com"
+                    ]
+                },
+                "Action": [
+                    "sts:AssumeRole"
+                ]
+            }
+        ]
+    }
+
+    try:
+        _logger.info(f"Creating role {role_name}")
+        iam_client.create_role(
+            AssumeRolePolicyDocument=json.dumps(assume_role_policy),
+            Description="Service linked role for AWS Cloud9",
+            Path="/service-role/",
+            RoleName=role_name,
+            Tags=[
+                {"Key": "ADDF_DEPLOYMENT_NAME", "Value": os.getenv("ADDF_DEPLOYMENT_NAME")},
+                {"Key": "ADDF_MODULE_NAME", "Value": os.getenv("ADDF_MODULE_NAME")},
+            ]
+        )
+    except Exception as err:
+        raise err
+
+    time.sleep(5)
+
+    try:
+        _logger.info(f"Attaching policy/AWSCloud9SSMInstanceProfile to {role_name}")
+        iam_client.attach_role_policy(
+            RoleName=role_name,
+            PolicyArn="arn:aws:iam::aws:policy/AWSCloud9SSMInstanceProfile"
+        )
+    except Exception as err:
+        raise err
+
+def create_instance_profile(instance_profile_name: str):
+    _logger.info(f"Creating instance profile {instance_profile_name}")
+    try:
+        iam_client.create_instance_profile(
+            InstanceProfileName=instance_profile_name,
+            Path="/cloud9/",
+        )
+    except iam_client.exceptions.NoSuchEntityException as err:
+        _logger.warning(f"The role {role_name} does not exist")
+
+if not check_access_role_exist(role_name=role_name):
+    create_access_role(role_name=role_name)
+
+instance_profile_exists, instance_profile_data = check_instance_profile_exist(instance_profile_name=instance_profile_name)
+if not instance_profile_exists:
+    create_instance_profile(instance_profile_name=instance_profile_name)
+else:
+    for role in instance_profile_data.get("InstanceProfile").get("Roles", []):
+        if role["RoleName"] == role_name:
+            break
+    else:
+        try:
+            attach_role_to_instance_profile(instance_profile_name=instance_profile_name, role_name=role_name)
+        except Exception as err:
+            raise err

--- a/modules/workbench/cloud9/stack.py
+++ b/modules/workbench/cloud9/stack.py
@@ -64,7 +64,7 @@ class Cloud9Stack(Stack):  # type: ignore
         instance_type : str
             Type of instance to launch
         name : str
-            The name of the environment
+            The name of the Cloud9 instance
         owner_arn : str
             The Amazon Resource Name (ARN) of the environment owner. This ARN can be the
             ARN of any AWS Identity and Access Management principal. If this value is


### PR DESCRIPTION
Fix issue where the parameter `CONNECTION_TYPE` if set to `CONNECT_SSM` would fail during the CDK deploy due to resources that the CDK does not create for you but expects them to be in the account in order for the instance to be created


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
