### PR TITLE
Fix deployment issue of aws batch

### DIFF
--- a/modules/core/aws-batch/app.py
+++ b/modules/core/aws-batch/app.py
@@ -51,13 +51,13 @@ CfnOutput(
             "BatchPolicyString": stack.batch_policy_document,
             "BatchSecurityGroupId": stack.batch_sg,
             "OnDemandJobQueueArn": stack.on_demand_jobqueue.job_queue_arn
-            if stack.on_demand_jobqueue.job_queue_arn
+            if stack.on_demand_jobqueue
             else "QUEUE NOT CREATED",
             "SpotJobQueueArn": stack.spot_jobqueue.job_queue_name
-            if stack.spot_jobqueue.job_queue_name
+            if stack.spot_jobqueue
             else "QUEUE NOT CREATED",
             "FargateJobQueueArn": stack.fargate_jobqueue.job_queue_name
-            if stack.fargate_jobqueue.job_queue_name
+            if stack.fargate_jobqueue
             else "QUEUE NOT CREATED",
         }
     ),

--- a/modules/core/aws-batch/stack.py
+++ b/modules/core/aws-batch/stack.py
@@ -228,6 +228,7 @@ class AwsBatch(Stack):
                     )
 
         # Outputs
+        self.on_demand_jobqueue  = None
         if on_demand_compute_env_list:
             self.on_demand_jobqueue = batch.JobQueue(
                 self,
@@ -237,6 +238,7 @@ class AwsBatch(Stack):
                 priority=1,
             )
 
+        self.spot_jobqueue  = None
         if spot_compute_env_list:
             self.spot_jobqueue = batch.JobQueue(
                 self,
@@ -246,6 +248,7 @@ class AwsBatch(Stack):
                 priority=1,
             )
 
+        self.fargate_jobqueue  = None
         if fargate_compute_env_list:
             self.fargate_jobqueue = batch.JobQueue(
                 self,


### PR DESCRIPTION
In case the manifest config skips certain compute environments, the stack itself is missing the ARNs and deployment raises an AttributeError. This fix makes queues optional and tests against None when creating
 CfnOutputs. This is tested in a custom stack only relying on AWS
Fargate.
