### PR TITLE
ADOT EKS Addon

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - integration with calico for network level isolation
 - integration with kyverno for implementing gov policy as code for k8s
 - Added detailed guide on how to launch EKS cluster in private and isolated subnets
+- Added Amazon EKS add-ons ADOT which is a secure, production-ready, AWS supported distribution of the OpenTelemetry project.
 
 ### **Changed**
 

--- a/data/eks_dockerimage-replication/versions/1.25.yaml
+++ b/data/eks_dockerimage-replication/versions/1.25.yaml
@@ -7,6 +7,8 @@ charts:
     version: 1.2.8
   calico:
     version: 3.25.1
+  cert_manager:
+    version: v1.11.1
   cluster_autoscaler:
     version: 9.27.0
     replication:

--- a/data/eks_dockerimage-replication/versions/default.yaml
+++ b/data/eks_dockerimage-replication/versions/default.yaml
@@ -101,6 +101,46 @@ charts:
         tag:
           location: chart
           path: appVersion
+  cert_manager:
+    name: cert-manager
+    repository: "https://charts.jetstack.io"
+    version: v1.11.1
+    images:
+      cert-manager-controller:
+        repository:
+          location: values
+          path: image.repository
+        tag:
+          location: chart
+          path: appVersion
+      cert-manager-webhook:
+        repository:
+          location: values
+          path: webhook.image.repository
+        tag:
+          location: chart
+          path: appVersion
+      cert-manager-acmesolver:
+        repository:
+          location: values
+          path: acmesolver.image.repository
+        tag:
+          location: chart
+          path: appVersion
+      cert-manager-startupapicheck:
+        repository:
+          location: values
+          path: startupapicheck.image.repository
+        tag:
+          location: chart
+          path: appVersion
+      cert-manager-cainjector:
+        repository:
+          location: values
+          path: cainjector.image.repository
+        tag:
+          location: chart
+          path: appVersion
   cluster_autoscaler:
     name: cluster-autoscaler
     repository: "https://kubernetes.github.io/autoscaler"

--- a/manifests/example-dev/core-modules.yaml
+++ b/manifests/example-dev/core-modules.yaml
@@ -125,6 +125,7 @@ parameters:
       deploy_cloudwatch_container_insights_metrics: True # We deploy it unless set to False
       deploy_cloudwatch_container_insights_logs: True
       cloudwatch_container_insights_logs_retention_days: 7
+      deploy_adot: False
       deploy_amp: False
       deploy_grafana_for_amp: False
       deploy_kured: False

--- a/modules/core/eks/README.md
+++ b/modules/core/eks/README.md
@@ -78,6 +78,7 @@ Security:
 - `deploy_secretsmanager_csi`: Deploys [Secrets Manager CSI driver](https://docs.aws.amazon.com/secretsmanager/latest/userguide/integrating_csi_driver.html) to interact with Secrets mounted as files. Default behavior is set to False
 - `deploy_cloudwatch_container_insights_metrics`: Deploys the [CloudWatch Agent](https://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/Container-Insights-EKS-agent.html) to ingest containers metrics into AWS Cloudwatch. Default behavior is set to False
 - `deploy_cloudwatch_container_insights_logs`: Deploys the [Fluent bit](https://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/Container-Insights-setup-logs-FluentBit.html) plugin to ingest containers logs into AWS Cloudwatch. Default behavior is set to False
+- `deploy_adot`: Deploys AWS Distro for OpenTelemetry (ADOT) which is a secure, production-ready, AWS supported distribution of the OpenTelemetry project.
 - `deploy_amp`: Deploys AWS Managed Prometheus for centralized log monitoring - ELK Stack. Default behavior is set to False
 - `deploy_grafana_for_amp`: Deploys Grafana boards for visualization of logs/metrics from Elasticsearch/Opensearch cluster. Default behavior is set to False
 - `deploy_kured`: Deploys [kured reboot daemon](https://github.com/kubereboot/kured) that performs safe automatic node reboots when the need to do so is indicated by the package management system of the underlying OS. Default behavior is set to False


### PR DESCRIPTION
*Issue #, if available:* ADOT add on feature in the EKS Cluster 

*Description of changes:*
The PR is to add the ADOT addon in the EKS cluster. CloudWatch Metrics is an AWS monitoring solution, and OpenTelemetry is a good compliment to it, so we have both as holistic solution. 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
