### PR TITLE
refactoring due to lambda changes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,7 +21,10 @@ Due to the removal of support for node 12.x in AWS Lambda, a number of modules u
 - modules/integration/eks-to-opensearch
 - modules/simulations/k8s-managed
 
-
+The following modules had their Lambda Layers requirements.txt modified:
+- modules/integration/ddb-to-opensearch (layer/requirements.txt)
+- modules/integration/emr-to-opensearch (layer/requirements.txt)
+- 
 ### **Removed**
 
 

--- a/modules/integration/ddb-to-opensearch/layers/requirements.txt
+++ b/modules/integration/ddb-to-opensearch/layers/requirements.txt
@@ -1,1 +1,2 @@
 requests-aws4auth==1.1.1
+urllib3==1.26.15

--- a/modules/integration/emr-to-opensearch/layers/requirements.txt
+++ b/modules/integration/emr-to-opensearch/layers/requirements.txt
@@ -1,2 +1,3 @@
 requests-aws4auth==1.1.1
 elasticsearch==7.13.4
+urllib3==1.26.15


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
The version of requirements for SSL vs the runtime of AWS lambda did not align.  Adding version lock of urllib3 to maintain working order

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
