### PR TITLE
Fix enable_sm_project function

### DIFF
--- a/modules/sagemaker/sagemaker-studio/functions/sm_studio/enable_sm_projects/requirements.txt
+++ b/modules/sagemaker/sagemaker-studio/functions/sm_studio/enable_sm_projects/requirements.txt
@@ -1,1 +1,2 @@
 cfnresponse
+urllib3<2 # Lock to version before braking change to urllib


### PR DESCRIPTION
Fix enable_sm_project function issue which was introduced by braking change in urllib3 version 2. Similar issue: https://github.com/psf/requests/issues/6443

Otherwise, error in cloudformation was raised
```
Received response status [FAILED] from custom resource. Message returned: Error: Unable to import module 'index': cannot import name 'DEFAULT_CIPHERS' from 'urllib3.util.ssl_
```
*Description of changes:*
Locking the version of urllib3 to be below 2.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
