### PR TITLE
Add Rosbag image pipeline stack and app tests

### DIFF
--- a/modules/analysis/rosbag-image-pipeline/coverage.ini
+++ b/modules/analysis/rosbag-image-pipeline/coverage.ini
@@ -1,3 +1,4 @@
 [run]
 omit =
     tests/*
+    setup.py

--- a/modules/analysis/rosbag-image-pipeline/tests/test_app.py
+++ b/modules/analysis/rosbag-image-pipeline/tests/test_app.py
@@ -1,0 +1,162 @@
+#  Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+#    Licensed under the Apache License, Version 2.0 (the "License").
+#    You may not use this file except in compliance with the License.
+#    You may obtain a copy of the License at
+#
+#        http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS,
+#    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#    See the License for the specific language governing permissions and
+#    limitations under the License.
+
+import os
+import sys
+from json import JSONDecodeError
+
+import pytest
+
+
+@pytest.fixture(scope="function")
+def stack_defaults():
+    os.environ["ADDF_DEPLOYMENT_NAME"] = "test-project"
+    os.environ["ADDF_MODULE_NAME"] = "test-deployment"
+
+    os.environ["CDK_DEFAULT_ACCOUNT"] = "111111111111"
+    os.environ["CDK_DEFAULT_REGION"] = "us-east-1"
+
+    os.environ["ADDF_PARAMETER_DAG_ID"] = "dag-id"
+    os.environ["ADDF_PARAMETER_VPC_ID"] = "vpc-id"
+    os.environ["ADDF_PARAMETER_MWAA_EXEC_ROLE"] = "mwaa-exec-role"
+    os.environ["ADDF_PARAMETER_FULL_ACCESS_POLICY_ARN"] = "full-access-policy-arn"
+    os.environ["ADDF_PARAMETER_SOURCE_BUCKET"] = "source-bucket"
+    os.environ["ADDF_PARAMETER_INTERMEDIATE_BUCKET"] = "intermediate-bucket"
+
+    os.environ["ADDF_PARAMETER_ON_DEMAND_JOB_QUEUE_ARN"] = "on-demand-job-queue-arn"
+    os.environ["ADDF_PARAMETER_SPOT_JOB_QUEUE_ARN"] = "spot-job-queue-arn"
+    os.environ["ADDF_PARAMETER_FARGATE_JOB_QUEUE_ARN"] = "fargate-job-queue-arn"
+    os.environ["ADDF_PARAMETER_PARQUET_BATCH_JOB_DEF_ARN"] = "parquet-batch-job-def-arn"
+    os.environ["ADDF_PARAMETER_PNG_BATCH_JOB_DEF_ARN"] = "png-batch-job-def-arn"
+    os.environ["ADDF_PARAMETER_OBJECT_DETECTION_IMAGE_URI"] = "object-detection-image-uri"
+    os.environ["ADDF_PARAMETER_OBJECT_DETECTION_IAM_ROLE"] = "object-detection-iam-role"
+
+    os.environ["ADDF_PARAMETER_LANE_DETECTION_IMAGE_URI"] = "lane-detection-image-uri"
+    os.environ["ADDF_PARAMETER_LANE_DETECTION_IAM_ROLE"] = "lane-detection-iam-role"
+    os.environ["ADDF_PARAMETER_IMAGE_TOPICS"] = "{}"
+    os.environ["ADDF_PARAMETER_SENSOR_TOPICS"] = "{}"
+
+    # Unload the app import so that subsequent tests don't reuse
+    if "app" in sys.modules:
+        del sys.modules["app"]
+
+
+def test_app(stack_defaults):
+    import app  # noqa: F401
+
+
+def test_png_batch_job_def_arn(stack_defaults):
+    del os.environ["ADDF_PARAMETER_PNG_BATCH_JOB_DEF_ARN"]
+
+    with pytest.raises(Exception) as e:
+        import app  # noqa: F401
+
+        assert "missing input parameter png-batch-job-def-arn" in str(e)
+
+
+def test_parquet_batch_job_def_arn(stack_defaults):
+    del os.environ["ADDF_PARAMETER_PARQUET_BATCH_JOB_DEF_ARN"]
+
+    with pytest.raises(Exception) as e:
+        import app  # noqa: F401
+
+        assert "missing input parameter parquet-batch-job-def-arn" in str(e)
+
+
+def test_object_detection_role(stack_defaults):
+    del os.environ["ADDF_PARAMETER_OBJECT_DETECTION_IAM_ROLE"]
+
+    with pytest.raises(Exception) as e:
+        import app  # noqa: F401
+
+        assert "missing input parameter object-detection-iam-role" in str(e)
+
+
+def test_object_detection_image_uri(stack_defaults):
+    del os.environ["ADDF_PARAMETER_LANE_DETECTION_IMAGE_URI"]
+
+    with pytest.raises(Exception) as e:
+        import app  # noqa: F401
+
+        assert "missing input parameter lane-detection-image-uri" in str(e)
+
+
+def test_lane_detection_role(stack_defaults):
+    del os.environ["ADDF_PARAMETER_LANE_DETECTION_IAM_ROLE"]
+
+    with pytest.raises(Exception) as e:
+        import app  # noqa: F401
+
+        assert "missing input parameter lane-detection-iam-role" in str(e)
+
+
+def test_lane_detection_image_uri(stack_defaults):
+    del os.environ["ADDF_PARAMETER_LANE_DETECTION_IMAGE_URI"]
+
+    with pytest.raises(Exception) as e:
+        import app  # noqa: F401
+
+        assert "missing input parameter lane-detection-image-uri" in str(e)
+
+
+def test_vpc_id(stack_defaults):
+    del os.environ["ADDF_PARAMETER_VPC_ID"]
+
+    with pytest.raises(Exception) as e:
+        import app  # noqa: F401
+
+        assert "missing input parameter vpc-id" in str(e)
+
+
+def test_mwaa_exec_role(stack_defaults):
+    del os.environ["ADDF_PARAMETER_MWAA_EXEC_ROLE"]
+
+    with pytest.raises(ValueError) as e:
+        import app  # noqa: F401
+
+        assert "MWAA Execution Role is missing." in str(e)
+
+
+def test_full_access_policy(stack_defaults):
+    del os.environ["ADDF_PARAMETER_FULL_ACCESS_POLICY_ARN"]
+
+    with pytest.raises(ValueError) as e:
+        import app  # noqa: F401
+
+        assert "S3 Full Access Policy ARN is missing." in str(e)
+
+
+def test_no_queue_provided():
+    del os.environ["ADDF_PARAMETER_ON_DEMAND_JOB_QUEUE_ARN"]
+    del os.environ["ADDF_PARAMETER_SPOT_JOB_QUEUE_ARN"]
+    del os.environ["ADDF_PARAMETER_FARGATE_JOB_QUEUE_ARN"]
+
+    with pytest.raises(ValueError) as e:
+        import app  # noqa: F401
+
+        assert "Requires at least one job queue." in str(e)
+
+
+def test_image_topics_no_json(stack_defaults):
+    os.environ["ADDF_PARAMETER_IMAGE_TOPICS"] = "no json"
+
+    with pytest.raises(JSONDecodeError):
+        import app  # noqa: F401
+
+
+def test_sensor_topics_no_json(stack_defaults):
+    os.environ["ADDF_PARAMETER_SENSOR_TOPICS"] = "no json"
+
+    with pytest.raises(JSONDecodeError):
+        import app  # noqa: F401

--- a/modules/analysis/rosbag-image-pipeline/tests/test_stack.py
+++ b/modules/analysis/rosbag-image-pipeline/tests/test_stack.py
@@ -1,2 +1,149 @@
-def test_placeholder() -> None:
-    return None
+#  Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+#    Licensed under the Apache License, Version 2.0 (the "License").
+#    You may not use this file except in compliance with the License.
+#    You may obtain a copy of the License at
+#
+#        http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS,
+#    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#    See the License for the specific language governing permissions and
+#    limitations under the License.
+
+import os
+import sys
+
+import aws_cdk as cdk
+import pytest
+from aws_cdk.assertions import Template
+
+
+@pytest.fixture(scope="function")
+def stack_defaults():
+    os.environ["CDK_DEFAULT_ACCOUNT"] = "111111111111"
+    os.environ["CDK_DEFAULT_REGION"] = "us-east-1"
+
+    # Unload the app import so that subsequent tests don't reuse
+
+    if "stack" in sys.modules:
+        del sys.modules["stack"]
+
+
+def iam_policy() -> dict:
+    return {
+        "Policies": [
+            {
+                "PolicyDocument": {
+                    "Statement": [
+                        {
+                            "Action": "dynamodb:*",
+                            "Effect": "Allow",
+                            "Resource": "arn:aws:dynamodb:us-east-1:111111111111:table/addf-test-deployment-test-module*",
+                        },
+                        {
+                            "Action": "ecr:*",
+                            "Effect": "Allow",
+                            "Resource": "arn:aws:ecr:us-east-1:111111111111:repository/addf-test-deployment-test-module*",
+                        },
+                        {
+                            "Action": [
+                                "batch:UntagResource",
+                                "batch:DeregisterJobDefinition",
+                                "batch:TerminateJob",
+                                "batch:CancelJob",
+                                "batch:SubmitJob",
+                                "batch:RegisterJobDefinition",
+                                "batch:TagResource",
+                            ],
+                            "Effect": "Allow",
+                            "Resource": [
+                                "job-queue-1",
+                                "job-queue-2",
+                                "job-def-1",
+                                "job-def-2",
+                                "arn:aws:batch:us-east-1:111111111111:job/*",
+                            ],
+                        },
+                        {
+                            "Action": "iam:PassRole",
+                            "Effect": "Allow",
+                            "Resource": [
+                                "obj-detection-role",
+                                "lane-detection-role",
+                            ],
+                        },
+                        {
+                            "Action": ["batch:Describe*", "batch:List*"],
+                            "Effect": "Allow",
+                            "Resource": "*",
+                        },
+                        {
+                            "Action": ["s3:GetObject", "s3:GetObjectAcl", "s3:ListBucket"],
+                            "Effect": "Allow",
+                            "Resource": ["arn:aws:s3:::addf-*", "arn:aws:s3:::addf-*/*"],
+                        },
+                    ]
+                }
+            }
+        ],
+    }
+
+
+def test_stack(stack_defaults):
+    import stack
+
+    app = cdk.App()
+    project_name = "test-project"
+    dep_name = "test-deployment"
+    mod_name = "test-module"
+
+    rosbag_stack = stack.AwsBatchPipeline(
+        scope=app,
+        id=f"{project_name}-{dep_name}-{mod_name}",
+        deployment_name=dep_name,
+        module_name=mod_name,
+        vpc_id="vpc-id",
+        mwaa_exec_role="mwaa-exec-role",
+        bucket_access_policy="bucket-access-policy",
+        object_detection_role="obj-detection-role",
+        lane_detection_role="lane-detection-role",
+        job_queues=["job-queue-1", "job-queue-2"],
+        job_definitions=["job-def-1", "job-def-2"],
+        env=cdk.Environment(account=(os.environ["CDK_DEFAULT_ACCOUNT"]), region=(os.environ["CDK_DEFAULT_REGION"])),
+    )
+    template = Template.from_stack(rosbag_stack)
+
+    template.resource_count_is("AWS::DynamoDB::Table", 1)
+
+    template.resource_count_is("AWS::IAM::Role", 1)
+    template.has_resource_properties(
+        "AWS::IAM::Role",
+        {
+            "AssumeRolePolicyDocument": {
+                "Statement": [
+                    {
+                        "Action": "sts:AssumeRole",
+                        "Effect": "Allow",
+                        "Principal": {"AWS": "mwaa-exec-role"},
+                    }
+                ],
+                "Version": "2012-10-17",
+            },
+            "ManagedPolicyArns": [
+                "bucket-access-policy",
+                {
+                    "Fn::Join": [
+                        "",
+                        [
+                            "arn:",
+                            {"Ref": "AWS::Partition"},
+                            ":iam::aws:policy/AmazonSageMakerFullAccess",
+                        ],
+                    ]
+                },
+            ],
+        },
+    )
+    template.has_resource_properties("AWS::IAM::Role", iam_policy())


### PR DESCRIPTION
Adding unit tests for `rosbag-image-pipeline` stack and app. (This PR does not include tests for `image_dags`)