### PR TITLE
feat: Add support for integration testing

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -388,3 +388,6 @@ seedfarmer.gitmodules*
 
 # terraform
 .terraform*
+
+# integration testing
+*/*/integ/deployment.yaml

--- a/manifests/aws-solutions/docker-image-modules.yaml
+++ b/manifests/aws-solutions/docker-image-modules.yaml
@@ -11,6 +11,8 @@ parameters:
     value: 2
   - name: memory-mib
     value: 8192
+  - name: removal-policy
+    value: DESTROY
   - name: full-access-policy-arn
     valueFrom:
       moduleMetadata:
@@ -35,6 +37,8 @@ parameters:
     value: 1280
   - name: resized-height
     value: 720
+  - name: removal-policy
+    value: DESTROY
   - name: full-access-policy-arn
     valueFrom:
       moduleMetadata:
@@ -45,6 +49,8 @@ parameters:
 name: object-detection
 path: git::https://github.com/awslabs/autonomous-driving-data-framework.git//modules/post-processing/yolo-object-detection
 parameters:
+  - name: removal-policy
+    value: DESTROY
   - name: full-access-policy-arn
     valueFrom:
       moduleMetadata:
@@ -55,6 +61,8 @@ parameters:
 name: lane-detection
 path: git::https://github.com/awslabs/autonomous-driving-data-framework.git//modules/post-processing/yolop-lane-detection
 parameters:
+  - name: removal-policy
+    value: DESTROY
   - name: full-access-policy-arn
     valueFrom:
       moduleMetadata:

--- a/manifests/aws-solutions/integ/addf-modules.yaml
+++ b/manifests/aws-solutions/integ/addf-modules.yaml
@@ -1,0 +1,23 @@
+name: aws-solutions # replace the name with your interested deployment name
+toolchainRegion: us-west-2 # replace the region of interest here
+forceDependencyRedeploy: True
+groups:
+  - name: optionals
+    path: manifests/aws-solutions/optional-modules.yaml
+  - name: core
+    path: manifests/aws-solutions/core-modules.yaml
+  - name: docker-images
+    path: manifests/aws-solutions/docker-image-modules.yaml
+  - name: analysis
+    path: manifests/aws-solutions/aws-analysis-modules.yaml
+  - name: integration
+    path: manifests/aws-solutions/integration-modules.yaml
+targetAccountMappings:
+  - alias: primary
+    accountId: XXXXXXXX # replace the account ID here
+    default: true
+    parametersGlobal:
+      dockerCredentialsSecret: aws-addf-docker-credentials
+    regionMappings:
+      - region: us-west-2 # replace the region of interest here
+        default: true

--- a/manifests/aws-solutions/integ/idf-modules.yaml
+++ b/manifests/aws-solutions/integ/idf-modules.yaml
@@ -1,0 +1,23 @@
+name: aws-solutions # replace the name with your interested deployment name
+toolchainRegion: us-west-2 # replace the region of interest here
+forceDependencyRedeploy: True
+groups:
+  - name: optionals
+    path: manifests/aws-solutions/optional-modules.yaml
+  - name: core
+    path: manifests/aws-solutions/core-modules.yaml
+  - name: docker-images
+    path: manifests/aws-solutions/docker-image-modules.yaml
+  - name: analysis
+    path: manifests/aws-solutions/aws-analysis-modules.yaml
+  - name: integration
+    path: manifests/aws-solutions/integration-modules.yaml
+targetAccountMappings:
+  - alias: primary
+    accountId: XXXXXXXX # replace the account ID here
+    default: true
+    parametersGlobal:
+      dockerCredentialsSecret: aws-addf-docker-credentials
+    regionMappings:
+      - region: us-west-2 # replace the region of interest here
+        default: true

--- a/manifests/aws-solutions/integ/idf-modules.yaml
+++ b/manifests/aws-solutions/integ/idf-modules.yaml
@@ -6,12 +6,6 @@ groups:
     path: manifests/aws-solutions/optional-modules.yaml
   - name: core
     path: manifests/aws-solutions/core-modules.yaml
-  - name: docker-images
-    path: manifests/aws-solutions/docker-image-modules.yaml
-  - name: analysis
-    path: manifests/aws-solutions/aws-analysis-modules.yaml
-  - name: integration
-    path: manifests/aws-solutions/integration-modules.yaml
 targetAccountMappings:
   - alias: primary
     accountId: XXXXXXXX # replace the account ID here

--- a/manifests/aws-solutions/integ/manifest-update.py
+++ b/manifests/aws-solutions/integ/manifest-update.py
@@ -1,0 +1,25 @@
+import sys
+import yaml
+
+if len(sys.argv) != 4:
+    print(
+        "Usage: python manifest-update.py [TOOLCHAIN REGION] [TARGET REGION] [TARGET ACCOUNT]"
+    )
+    exit(1)
+
+toolchain_region = sys.argv[1]
+target_region = sys.argv[2]
+target_account = sys.argv[3]
+with open("idf-modules.yaml", "r") as file:
+    data = yaml.safe_load(file)
+
+data["toolchainRegion"] = toolchain_region
+data["targetAccountMappings"][0]["accountId"] = target_account
+data["targetAccountMappings"][0]["regionMappings"][0]["region"] = target_region
+
+with open("deployment.yaml", "w") as file:
+    yaml.dump(data, file)
+
+print(
+    f"manifest has been updated and seedfarmer will deploy the following: \n{open('deployment.yaml').read()}"
+)

--- a/manifests/aws-solutions/integ/manifest-update.py
+++ b/manifests/aws-solutions/integ/manifest-update.py
@@ -1,16 +1,17 @@
 import sys
 import yaml
 
-if len(sys.argv) != 4:
+if len(sys.argv) != 5:
     print(
-        "Usage: python manifest-update.py [TOOLCHAIN REGION] [TARGET REGION] [TARGET ACCOUNT]"
+        "Usage: python manifest-update.py [MANIFEST PATH][TOOLCHAIN REGION] [TARGET REGION] [TARGET ACCOUNT]"
     )
     exit(1)
 
-toolchain_region = sys.argv[1]
-target_region = sys.argv[2]
-target_account = sys.argv[3]
-with open("idf-modules.yaml", "r") as file:
+manifest_path = sys.argv[1]
+toolchain_region = sys.argv[2]
+target_region = sys.argv[3]
+target_account = sys.argv[4]
+with open(manifest_path, "r") as file:
     data = yaml.safe_load(file)
 
 data["toolchainRegion"] = toolchain_region

--- a/modules/post-processing/yolo-object-detection/app.py
+++ b/modules/post-processing/yolo-object-detection/app.py
@@ -1,6 +1,6 @@
 import os
 
-from aws_cdk import App, CfnOutput, Environment
+from aws_cdk import App, CfnOutput, Environment, RemovalPolicy
 
 from stack import ObjectDetection
 
@@ -13,6 +13,7 @@ def _param(name: str) -> str:
 
 
 full_access_policy = os.getenv(_param("FULL_ACCESS_POLICY_ARN"))
+removal_policy = os.getenv(_param("REMOVAL_POLICY"), "")
 
 if not full_access_policy:
     raise ValueError("S3 Full Access Policy ARN is missing.")
@@ -29,6 +30,7 @@ stack = ObjectDetection(
         region=os.environ["CDK_DEFAULT_REGION"],
     ),
     s3_access_policy=full_access_policy,
+    removal_policy=removal_policy
 )
 
 base_image = (

--- a/modules/post-processing/yolo-object-detection/app.py
+++ b/modules/post-processing/yolo-object-detection/app.py
@@ -30,7 +30,7 @@ stack = ObjectDetection(
         region=os.environ["CDK_DEFAULT_REGION"],
     ),
     s3_access_policy=full_access_policy,
-    removal_policy=removal_policy
+    removal_policy=RemovalPolicy.DESTROY if removal_policy.upper() == "DESTROY" else None,
 )
 
 base_image = (

--- a/modules/post-processing/yolo-object-detection/stack.py
+++ b/modules/post-processing/yolo-object-detection/stack.py
@@ -17,7 +17,7 @@ from typing import Any, cast
 
 import aws_cdk.aws_ecr as ecr
 import aws_cdk.aws_iam as iam
-from aws_cdk import Duration, Stack, Tags
+from aws_cdk import Duration, RemovalPolicy, Stack, Tags
 from constructs import Construct, IConstruct
 
 _logger: logging.Logger = logging.getLogger(__name__)
@@ -32,6 +32,7 @@ class ObjectDetection(Stack):
         deployment_name: str,
         module_name: str,
         s3_access_policy: str,
+        removal_policy: RemovalPolicy = RemovalPolicy.RETAIN,
         **kwargs: Any,
     ) -> None:
         super().__init__(
@@ -48,7 +49,7 @@ class ObjectDetection(Stack):
         dep_mod = f"addf-{deployment_name}-{module_name}"
 
         self.repository_name = dep_mod
-        repo = ecr.Repository(self, id=self.repository_name, repository_name=self.repository_name)
+        repo = ecr.Repository(self, id=self.repository_name, repository_name=self.repository_name, removal_policy=removal_policy)
         self.image_uri = f"{repo.repository_uri}:latest"
 
         policy_statements = [

--- a/modules/post-processing/yolo-object-detection/stack.py
+++ b/modules/post-processing/yolo-object-detection/stack.py
@@ -49,7 +49,9 @@ class ObjectDetection(Stack):
         dep_mod = f"addf-{deployment_name}-{module_name}"
 
         self.repository_name = dep_mod
-        repo = ecr.Repository(self, id=self.repository_name, repository_name=self.repository_name, removal_policy=removal_policy)
+        repo = ecr.Repository(
+            self, id=self.repository_name, repository_name=self.repository_name, removal_policy=removal_policy
+        )
         self.image_uri = f"{repo.repository_uri}:latest"
 
         policy_statements = [

--- a/modules/post-processing/yolo-object-detection/stack.py
+++ b/modules/post-processing/yolo-object-detection/stack.py
@@ -13,7 +13,7 @@
 #    limitations under the License.
 
 import logging
-from typing import Any, cast
+from typing import Any, Optional, cast
 
 import aws_cdk.aws_ecr as ecr
 import aws_cdk.aws_iam as iam
@@ -32,7 +32,7 @@ class ObjectDetection(Stack):
         deployment_name: str,
         module_name: str,
         s3_access_policy: str,
-        removal_policy: RemovalPolicy = RemovalPolicy.RETAIN,
+        removal_policy: Optional[RemovalPolicy] = RemovalPolicy.RETAIN,
         **kwargs: Any,
     ) -> None:
         super().__init__(

--- a/modules/post-processing/yolop-lane-detection/app.py
+++ b/modules/post-processing/yolop-lane-detection/app.py
@@ -30,7 +30,7 @@ stack = LaneDetection(
         region=os.environ["CDK_DEFAULT_REGION"],
     ),
     s3_access_policy=full_access_policy,
-    removal_policy=removal_policy,
+    removal_policy=RemovalPolicy.DESTROY if removal_policy.upper() == "DESTROY" else None,
 )
 
 

--- a/modules/post-processing/yolop-lane-detection/app.py
+++ b/modules/post-processing/yolop-lane-detection/app.py
@@ -1,6 +1,6 @@
 import os
 
-from aws_cdk import App, CfnOutput, Environment
+from aws_cdk import App, CfnOutput, Environment, RemovalPolicy
 
 from stack import LaneDetection
 
@@ -13,6 +13,7 @@ def _param(name: str) -> str:
 
 
 full_access_policy = os.getenv(_param("FULL_ACCESS_POLICY_ARN"))
+removal_policy = os.getenv(_param("REMOVAL_POLICY"), "")
 
 if not full_access_policy:
     raise ValueError("S3 Full Access Policy ARN is missing.")
@@ -29,6 +30,7 @@ stack = LaneDetection(
         region=os.environ["CDK_DEFAULT_REGION"],
     ),
     s3_access_policy=full_access_policy,
+    removal_policy=removal_policy,
 )
 
 

--- a/modules/post-processing/yolop-lane-detection/stack.py
+++ b/modules/post-processing/yolop-lane-detection/stack.py
@@ -49,7 +49,9 @@ class LaneDetection(Stack):
         dep_mod = f"addf-{deployment_name}-{module_name}"
 
         self.repository_name = dep_mod
-        repo = ecr.Repository(self, id=self.repository_name, repository_name=self.repository_name, removal_policy=removal_policy)
+        repo = ecr.Repository(
+            self, id=self.repository_name, repository_name=self.repository_name, removal_policy=removal_policy
+        )
         self.image_uri = f"{repo.repository_uri}:smprocessor"
 
         policy_statements = [

--- a/modules/post-processing/yolop-lane-detection/stack.py
+++ b/modules/post-processing/yolop-lane-detection/stack.py
@@ -13,7 +13,7 @@
 #    limitations under the License.
 
 import logging
-from typing import Any, cast
+from typing import Any, Optional, cast
 
 import aws_cdk.aws_ecr as ecr
 import aws_cdk.aws_iam as iam
@@ -32,7 +32,7 @@ class LaneDetection(Stack):
         deployment_name: str,
         module_name: str,
         s3_access_policy: str,
-        removal_policy: RemovalPolicy = RemovalPolicy.RETAIN,
+        removal_policy: Optional[RemovalPolicy] = RemovalPolicy.RETAIN,
         **kwargs: Any,
     ) -> None:
         super().__init__(

--- a/modules/post-processing/yolop-lane-detection/stack.py
+++ b/modules/post-processing/yolop-lane-detection/stack.py
@@ -17,7 +17,7 @@ from typing import Any, cast
 
 import aws_cdk.aws_ecr as ecr
 import aws_cdk.aws_iam as iam
-from aws_cdk import Duration, Stack, Tags
+from aws_cdk import Duration, RemovalPolicy, Stack, Tags
 from constructs import Construct, IConstruct
 
 _logger: logging.Logger = logging.getLogger(__name__)
@@ -32,6 +32,7 @@ class LaneDetection(Stack):
         deployment_name: str,
         module_name: str,
         s3_access_policy: str,
+        removal_policy: RemovalPolicy = RemovalPolicy.RETAIN,
         **kwargs: Any,
     ) -> None:
         super().__init__(
@@ -48,7 +49,7 @@ class LaneDetection(Stack):
         dep_mod = f"addf-{deployment_name}-{module_name}"
 
         self.repository_name = dep_mod
-        repo = ecr.Repository(self, id=self.repository_name, repository_name=self.repository_name)
+        repo = ecr.Repository(self, id=self.repository_name, repository_name=self.repository_name, removal_policy=removal_policy)
         self.image_uri = f"{repo.repository_uri}:smprocessor"
 
         policy_statements = [

--- a/modules/sensor-extraction/ros-to-parquet/app.py
+++ b/modules/sensor-extraction/ros-to-parquet/app.py
@@ -1,6 +1,6 @@
 import os
 
-from aws_cdk import App, CfnOutput, Environment
+from aws_cdk import App, CfnOutput, Environment, RemovalPolicy
 from stack import RosToParquetBatchJob
 
 deployment_name = os.getenv("ADDF_DEPLOYMENT_NAME", "")
@@ -17,6 +17,7 @@ retries = int(os.getenv(_param("RETRIES"), 1))
 timeout_seconds = int(os.getenv(_param("TIMEOUT_SECONDS"), 60))
 vcpus = int(os.getenv(_param("VCPUS"), 4))
 memory_limit_mib = int(os.getenv(_param("MEMORY_MIB"), 16384))
+removal_policy = os.getenv(_param("REMOVAL_POLICY"), "")
 
 if not full_access_policy:
     raise ValueError("S3 Full Access Policy ARN is missing.")
@@ -39,6 +40,7 @@ stack = RosToParquetBatchJob(
     vcpus=vcpus,
     memory_limit_mib=memory_limit_mib,
     s3_access_policy=full_access_policy,
+    removal_policy=RemovalPolicy.DESTROY if removal_policy.upper() == "DESTROY" else None,
 )
 
 CfnOutput(

--- a/modules/sensor-extraction/ros-to-parquet/stack.py
+++ b/modules/sensor-extraction/ros-to-parquet/stack.py
@@ -20,7 +20,7 @@ import aws_cdk.aws_batch_alpha as batch
 import aws_cdk.aws_ecr as ecr
 import aws_cdk.aws_ecs as ecs
 import aws_cdk.aws_iam as iam
-from aws_cdk import Duration, Stack, Tags
+from aws_cdk import Duration, RemovalPolicy, Stack, Tags
 from aws_cdk.aws_ecr_assets import DockerImageAsset
 from cdk_ecr_deployment import DockerImageName, ECRDeployment
 from constructs import Construct, IConstruct
@@ -42,6 +42,7 @@ class RosToParquetBatchJob(Stack):
         timeout_seconds: int,
         vcpus: int,
         memory_limit_mib: int,
+        removal_policy: RemovalPolicy = RemovalPolicy.RETAIN,
         **kwargs: Any,
     ) -> None:
         super().__init__(
@@ -62,7 +63,7 @@ class RosToParquetBatchJob(Stack):
         dep_mod = f"addf-{deployment_name}-{module_name}"
 
         self.repository_name = dep_mod
-        repo = ecr.Repository(self, id=self.repository_name, repository_name=self.repository_name)
+        repo = ecr.Repository(self, id=self.repository_name, repository_name=self.repository_name, removal_policy=removal_policy)
 
         local_image = DockerImageAsset(
             self,

--- a/modules/sensor-extraction/ros-to-parquet/stack.py
+++ b/modules/sensor-extraction/ros-to-parquet/stack.py
@@ -63,7 +63,9 @@ class RosToParquetBatchJob(Stack):
         dep_mod = f"addf-{deployment_name}-{module_name}"
 
         self.repository_name = dep_mod
-        repo = ecr.Repository(self, id=self.repository_name, repository_name=self.repository_name, removal_policy=removal_policy)
+        repo = ecr.Repository(
+            self, id=self.repository_name, repository_name=self.repository_name, removal_policy=removal_policy
+        )
 
         local_image = DockerImageAsset(
             self,

--- a/modules/sensor-extraction/ros-to-png/app.py
+++ b/modules/sensor-extraction/ros-to-png/app.py
@@ -1,6 +1,6 @@
 import os
 
-from aws_cdk import App, CfnOutput, Environment
+from aws_cdk import App, CfnOutput, Environment, RemovalPolicy
 from stack import RosToPngBatchJob
 
 deployment_name = os.getenv("ADDF_DEPLOYMENT_NAME", "")
@@ -18,6 +18,8 @@ vcpus = int(os.getenv(_param("VCPUS"), 4))
 memory_limit_mib = int(os.getenv(_param("MEMORY_MIB"), 16384))
 resized_width = os.getenv(_param("RESIZED_WIDTH"))
 resized_height = os.getenv(_param("RESIZED_HEIGHT"))
+removal_policy = os.getenv(_param("REMOVAL_POLICY"), "")
+
 
 if resized_width:
     resized_width = int(resized_width)
@@ -46,6 +48,7 @@ stack = RosToPngBatchJob(
     s3_access_policy=full_access_policy,
     resized_width=resized_width,
     resized_height=resized_height,
+    removal_policy=RemovalPolicy.DESTROY if removal_policy.upper() == "DESTROY" else None,
 )
 
 CfnOutput(

--- a/modules/sensor-extraction/ros-to-png/stack.py
+++ b/modules/sensor-extraction/ros-to-png/stack.py
@@ -21,7 +21,7 @@ import aws_cdk.aws_batch_alpha as batch
 import aws_cdk.aws_ecr as ecr
 import aws_cdk.aws_ecs as ecs
 import aws_cdk.aws_iam as iam
-from aws_cdk import Duration, Stack, Tags
+from aws_cdk import Duration, RemovalPolicy, Stack, Tags
 from aws_cdk.aws_ecr_assets import DockerImageAsset
 from cdk_ecr_deployment import DockerImageName, ECRDeployment
 from constructs import Construct, IConstruct
@@ -44,6 +44,7 @@ class RosToPngBatchJob(Stack):
         memory_limit_mib: int,
         resized_width: int,
         resized_height: int,
+        removal_policy: RemovalPolicy = RemovalPolicy.RETAIN,
         **kwargs: Any,
     ) -> None:
         super().__init__(
@@ -61,7 +62,7 @@ class RosToPngBatchJob(Stack):
         dep_mod = f"addf-{deployment_name}-{module_name}"
 
         self.repository_name = dep_mod
-        repo = ecr.Repository(self, id=self.repository_name, repository_name=self.repository_name)
+        repo = ecr.Repository(self, id=self.repository_name, repository_name=self.repository_name, removal_policy=removal_policy)
 
         local_image = DockerImageAsset(
             self,

--- a/modules/sensor-extraction/ros-to-png/stack.py
+++ b/modules/sensor-extraction/ros-to-png/stack.py
@@ -62,7 +62,9 @@ class RosToPngBatchJob(Stack):
         dep_mod = f"addf-{deployment_name}-{module_name}"
 
         self.repository_name = dep_mod
-        repo = ecr.Repository(self, id=self.repository_name, repository_name=self.repository_name, removal_policy=removal_policy)
+        repo = ecr.Repository(
+            self, id=self.repository_name, repository_name=self.repository_name, removal_policy=removal_policy
+        )
 
         local_image = DockerImageAsset(
             self,


### PR DESCRIPTION
**Does not need to be merged until integration testing is finalized**

### Adds support for integration testing
- Adds manifests used by integration testing
- Adds `removal_policy` params to modules utilizing `ecr.Repository`. Default is to Retain which will not work in integration testing as resources need to be recreated each invocation.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
