### PR TITLE
adding lifecycle rule for logs bucket - artifacts-bucket-logs/

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,6 +51,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Refactored Rosbag Image pipeline module to work with mwaa 2.6.3
 - fixed the dependabot alerts (apache-airflow)
 - refactored pyspark script of scene-detect in rosbag-image-processing module
+- `datalake-buckets` has LifecycleRule on `artifacts-bucket-logs` added due to number of MWAA access logs
 
 ### **Removed**
 

--- a/modules/optionals/datalake-buckets/README.md
+++ b/modules/optionals/datalake-buckets/README.md
@@ -34,6 +34,9 @@ None
 - `retention-type`: type of data retention policy when deleteing the buckets
   - `DESTROY` or `RETAIN`
   - Assumed to be `DESTROY`
+- `artifacts-log-retention`: the number of days back to keep the logs in `artifacts-bucket-logs`
+  - this is to prevent large number of logs filling from MWAA
+  - shoud be an integer - "2"
 
 
 ### Module Metadata Outputs

--- a/modules/optionals/datalake-buckets/app.py
+++ b/modules/optionals/datalake-buckets/app.py
@@ -16,6 +16,7 @@ hash = os.getenv("ADDF_HASH", "")
 # App Env vars
 buckets_encryption_type = os.getenv("ADDF_PARAMETER_ENCRYPTION_TYPE", "SSE")
 buckets_retention = os.getenv("ADDF_PARAMETER_RETENTION_TYPE", "DESTROY")
+artifact_logs_retention = os.getenv("ADDF_PARAMETER_ARTIFACTS_LOG_RETENTION", "2")
 
 if buckets_retention not in ["DESTROY", "RETAIN"]:
     raise ValueError("The only RETENTION_TYPE values accepted are 'DESTROY' and 'RETAIN' ")
@@ -36,6 +37,7 @@ stack = DataLakeBucketsStack(
     hash=hash,
     buckets_encryption_type=buckets_encryption_type,
     buckets_retention=buckets_retention,
+    artifacts_log_retention=int(artifact_logs_retention),
     env=aws_cdk.Environment(
         account=os.environ["CDK_DEFAULT_ACCOUNT"],
         region=os.environ["CDK_DEFAULT_REGION"],

--- a/modules/optionals/datalake-buckets/stack.py
+++ b/modules/optionals/datalake-buckets/stack.py
@@ -25,6 +25,7 @@ class DataLakeBucketsStack(Stack):  # type: ignore
         hash: str,
         buckets_encryption_type: str,
         buckets_retention: str,
+        artifacts_log_retention: int,
         **kwargs: Any,
     ) -> None:
         # CDK Env Vars
@@ -50,7 +51,7 @@ class DataLakeBucketsStack(Stack):  # type: ignore
             # MWAA is very chatty, logs need to be cleaned via LifecycleRule
             lifecycle_rules=[
                 aws_s3.LifecycleRule(
-                    expiration=Duration.days(2),
+                    expiration=Duration.days(artifacts_log_retention),
                     enabled=True,
                     prefix="artifacts-bucket-logs/",
                 )

--- a/modules/optionals/datalake-buckets/stack.py
+++ b/modules/optionals/datalake-buckets/stack.py
@@ -8,7 +8,7 @@ import aws_cdk
 import aws_cdk.aws_iam as aws_iam
 import aws_cdk.aws_s3 as aws_s3
 import cdk_nag
-from aws_cdk import Aspects, Stack, Tags
+from aws_cdk import Aspects, Duration, Stack, Tags
 from cdk_nag import NagPackSuppression, NagSuppressions
 from constructs import Construct, IConstruct
 
@@ -47,6 +47,14 @@ class DataLakeBucketsStack(Stack):  # type: ignore
             block_public_access=aws_s3.BlockPublicAccess.BLOCK_ALL,
             object_ownership=aws_s3.ObjectOwnership.BUCKET_OWNER_PREFERRED,
             enforce_ssl=True,
+            # MWAA is very chatty, logs need to be cleaned via LifecycleRule
+            lifecycle_rules=[
+                aws_s3.LifecycleRule(
+                    expiration=Duration.days(2),
+                    enabled=True,
+                    prefix="artifacts-bucket-logs/",
+                )
+            ],
         )
 
         raw_bucket = aws_s3.Bucket(

--- a/modules/optionals/datalake-buckets/tests/test_stack.py
+++ b/modules/optionals/datalake-buckets/tests/test_stack.py
@@ -35,6 +35,7 @@ def test_synthesize_stack(stack_defaults):
         hash="hash",
         buckets_encryption_type="SSE",
         buckets_retention="DESTROY",
+        artifacts_log_retention=2,
         env=cdk.Environment(
             account=os.environ["CDK_DEFAULT_ACCOUNT"],
             region=os.environ["CDK_DEFAULT_REGION"],


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
MWAA pings the artifacts bucket every 2 seconds...and the result is an access log to the logs bucket (700kb per) that over time cause the auto-delete of the lambda to time out due to the number of files to delete when destroying.  Adding a lifecycle rule to delele logs older that 2 days old in the `artifacts-bucket-logs/` prefix

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
