### PR TITLE
updating urllib3 to 1.26.17 manually - dependabot issues

### DIFF
--- a/modules/integration/efs-on-eks/requirements-dev.txt
+++ b/modules/integration/efs-on-eks/requirements-dev.txt
@@ -162,7 +162,7 @@ typing-extensions==4.1.1
     # via
     #   black
     #   mypy
-urllib3==1.26.9
+urllib3==1.26.17
     # via
     #   botocore
     #   requests

--- a/modules/integration/emr-to-opensearch/requirements.txt
+++ b/modules/integration/emr-to-opensearch/requirements.txt
@@ -59,5 +59,5 @@ six==1.16.0
     # via python-dateutil
 typing-extensions==4.2.0
     # via jsii
-urllib3==1.26.9
+urllib3==1.26.17
     # via botocore

--- a/modules/mlops/kubeflow-platform/requirements-dev.txt
+++ b/modules/mlops/kubeflow-platform/requirements-dev.txt
@@ -162,7 +162,7 @@ typing-extensions==4.1.1
     # via
     #   black
     #   mypy
-urllib3==1.26.9
+urllib3==1.26.17
     # via
     #   botocore
     #   requests

--- a/modules/mlops/kubeflow-users/requirements-dev.txt
+++ b/modules/mlops/kubeflow-users/requirements-dev.txt
@@ -162,7 +162,7 @@ typing-extensions==4.1.1
     # via
     #   black
     #   mypy
-urllib3==1.26.9
+urllib3==1.26.17
     # via
     #   botocore
     #   requests

--- a/modules/post-processing/lane-detection/requirements-dev.txt
+++ b/modules/post-processing/lane-detection/requirements-dev.txt
@@ -161,7 +161,7 @@ typing-extensions==4.3.0
     # via
     #   black
     #   mypy
-urllib3==1.26.11
+urllib3==1.26.17
     # via
     #   botocore
     #   requests

--- a/modules/post-processing/lane-detection/requirements.txt
+++ b/modules/post-processing/lane-detection/requirements.txt
@@ -64,5 +64,5 @@ typing-extensions==4.7.1
     # via
     #   -r requirements.in
     #   jsii
-urllib3==1.26.11
+urllib3==1.26.17
     # via botocore


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Fixing requirements files maullay to set urllib3~=1.26.17 as per depenabot issues:
234
235
252
258
260
261


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
