### PR TITLE
updating pillow version to 10.0.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -52,6 +52,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - fixed the dependabot alerts (apache-airflow)
 - refactored pyspark script of scene-detect in rosbag-image-processing module
 - `datalake-buckets` has LifecycleRule on `artifacts-bucket-logs` added due to number of MWAA access logs
+- updated `Pillow~=10.0.1` in modules/analysis/rosbag-image-pipeline/requirements-dev.txt
 
 ### **Removed**
 

--- a/modules/analysis/rosbag-image-pipeline/requirements-dev.txt
+++ b/modules/analysis/rosbag-image-pipeline/requirements-dev.txt
@@ -12,6 +12,6 @@ mypy-boto3-batch
 pytest-cov
 pytest-spark
 pyspark
-Pillow~=9.3.0
+Pillow~=10.0.1
 sagemaker==2.180.0
 emr_serverless @ https://github.com/aws-samples/emr-serverless-samples/releases/download/v1.0.1/mwaa_plugin.zip


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
The pillow version needed updating in `analysis/rosbag-image-pipeline/requirements-dev.txt` to avert a vulnerabilty:
ref #264 and #265 in Security Issues

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
