### PR TITLE
chore: Change sync workflow trigger

### DIFF
--- a/.github/workflows/gh-sync-cc.yaml
+++ b/.github/workflows/gh-sync-cc.yaml
@@ -61,7 +61,7 @@ jobs:
           
           cd scene-intelligence-with-rosbag-on-aws/
           git config --global user.email "ssriche@amazon.com"
-          git config --global user.name "Srinivas"
+          git config --global user.name "Github-CodeCommit-Sync"
           git config --global init.defaultBranch main
           git remote -v
           git branch -a

--- a/.github/workflows/gh-sync-cc.yaml
+++ b/.github/workflows/gh-sync-cc.yaml
@@ -4,8 +4,6 @@ on:
   # Triggers the workflow on push or pull request events but only for the "scene-intelligence-with-rosbag-on-aws" branch
   push:
     branches: ["scene-intelligence-with-rosbag-on-aws"]
-  pull_request:
-    branches: ["scene-intelligence-with-rosbag-on-aws"]
 
   # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:

--- a/.github/workflows/gh-sync-cc.yaml
+++ b/.github/workflows/gh-sync-cc.yaml
@@ -55,8 +55,9 @@ jobs:
           echo "Copying Manifest file contents..."
           cp -R manifests/aws-solutions/ scene-intelligence-with-rosbag-on-aws/manifests/
 
-          echo "Copying Readme changes..."
+          echo "Copying Root Directory  changes..."
           cp README.md scene-intelligence-with-rosbag-on-aws/
+          cp .viperlightignore scene-intelligence-with-rosbag-on-aws/
           
           cd scene-intelligence-with-rosbag-on-aws/
           git config --global user.email "ssriche@amazon.com"
@@ -67,7 +68,7 @@ jobs:
           git add -A
           git status
           if ! git diff-index --quiet HEAD; then
-            git commit -m "sync gh with cc"
+            git commit -m "${{ github.event.head_commit.message }}"
             git push origin main
           else
             echo "No change detected... nothing to commit..."


### PR DESCRIPTION
Change sync workflow to only trigger on pushes to branch `scene-intelligence-with-rosbag-on-aws`


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
