### PR TITLE
reducing named parameters

### DIFF
--- a/modules/sensor-extraction/ros-to-png/stack.py
+++ b/modules/sensor-extraction/ros-to-png/stack.py
@@ -24,7 +24,6 @@ class RosToPngBatchJob(Stack):
         self,
         scope: Construct,
         id: str,
-        *,
         deployment_name: str,
         module_name: str,
         s3_access_policy: str,
@@ -34,8 +33,8 @@ class RosToPngBatchJob(Stack):
         memory_limit_mib: int,
         resized_width: int,
         resized_height: int,
-        removal_policy: RemovalPolicy = RemovalPolicy.DESTROY,
         stack_description: str,
+        removal_policy: RemovalPolicy = RemovalPolicy.DESTROY,
         **kwargs: Any,
     ) -> None:
         super().__init__(


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
The ros-png module failed sonarqube due to having greater than 13 named parameters in stacky.py...this redices the number to 13

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
