### PR TITLE
adding capacity configs for fsx-lustre-on-eks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - updated fsx-lustre-on-eks module to create EKS namespace if it does not exist
 - fix removed default region from fsx-lustre-on-eks deployspec
 - update cdk version for 'fsx-lustre-on-eks' module
+- adding storage capacity configuration for `fsx-lusre-on-eks` module
 
 ### **Removed**
 

--- a/modules/integration/fsx-lustre-on-eks/README.md
+++ b/modules/integration/fsx-lustre-on-eks/README.md
@@ -36,7 +36,8 @@ with an atttached Security Group in the same VPC as the EKS cluster.  We do not 
   - this is to support secrets already defined in the [mlops/kf-users](../../mlops/kubeflow-users/README.md) module
 
 #### Optional
-NONE
+- `fsx-storage-capacity`: the amount (in GB) of storage, **defaults to 1200**, with the following guidelines:
+  -  valid values are 1200, 2400 , and increments of 3600
 
 #### Input Example
 ```yaml

--- a/modules/integration/fsx-lustre-on-eks/app.py
+++ b/modules/integration/fsx-lustre-on-eks/app.py
@@ -33,13 +33,17 @@ fsx_security_group_id = os.getenv(_param("FSX_SECURITY_GROUP_ID"))
 fsx_mount_name = os.getenv(_param("FSX_MOUNT_NAME"))
 fsx_dns_name = os.getenv(_param("FSX_DNS_NAME"))
 
+fsx_storage_capacity = int(os.getenv(_param("FSX_STORAGE_CAPACITY"), 1200))
+
 # This gets set in the deployspec...NOTE no PARAMETER prefix
 eks_namespace = os.getenv("EKS_NAMESPACE")
 
 if not eks_namespace:
-    print("No EKS Namespace defined...error")
-    exit(1)
+    raise ValueError("No EKS Namespace defined...error")
 
+
+if fsx_storage_capacity not in [1200, 2400] and (fsx_storage_capacity % 3600) != 0:
+    raise ValueError("Storage_capacity must be 1200, 2400 or an increment of 3600 - see README")
 
 app = App()
 
@@ -53,6 +57,7 @@ stack = FSXFileStorageOnEKS(
     fsx_security_group_id=cast(str, fsx_security_group_id),
     fsx_mount_name=cast(str, fsx_mount_name),
     fsx_dns_name=cast(str, fsx_dns_name),
+    fsx_storage_capacity=f"{fsx_storage_capacity}Gi",
     eks_cluster_name=cast(str, eks_cluster_name),
     eks_admin_role_arn=cast(str, eks_admin_role_arn),
     eks_oidc_arn=cast(str, eks_oidc_arn),

--- a/modules/integration/fsx-lustre-on-eks/stack_fsx_eks.py
+++ b/modules/integration/fsx-lustre-on-eks/stack_fsx_eks.py
@@ -22,6 +22,7 @@ class FSXFileStorageOnEKS(Stack):
         fsx_mount_name: str,
         fsx_file_system_id: str,
         fsx_security_group_id: str,
+        fsx_storage_capacity: str,
         eks_namespace: str,
         eks_cluster_name: str,
         eks_admin_role_arn: str,
@@ -123,7 +124,7 @@ class FSXFileStorageOnEKS(Stack):
                 "metadata": {"name": self.pv_name},
                 "spec": {
                     "storageClassName": self.storage_class_name,
-                    "capacity": {"storage": "1200Gi"},
+                    "capacity": {"storage": fsx_storage_capacity},
                     "volumeMode": "Filesystem",
                     "accessModes": ["ReadWriteMany"],
                     "mountOptions": ["flock"],

--- a/modules/integration/fsx-lustre-on-eks/tests/test_app.py
+++ b/modules/integration/fsx-lustre-on-eks/tests/test_app.py
@@ -1,0 +1,47 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+import os
+import sys
+
+import pytest
+
+
+@pytest.fixture(scope="function")
+def stack_defaults():
+    os.environ["AWS_CODESEEDER_NAME"] = "addf"
+    os.environ["ADDF_PROJECT_NAME"] = "test-project"
+    os.environ["ADDF_DEPLOYMENT_NAME"] = "test-deployment"
+    os.environ["ADDF_MODULE_NAME"] = "test-module"
+    os.environ["CDK_DEFAULT_ACCOUNT"] = "111111111111"
+    os.environ["CDK_DEFAULT_REGION"] = "us-east-1"
+    os.environ["ADDF_EKS_CLUSTER_NAME"] = "cluster"
+    os.environ["ADDF_EKS_CLUSTER_ADMIN_ROLE_ARN"] = "arn"
+    os.environ["ADDF_EKS_OIDC_ARN"] = "arn"
+    os.environ["ADDF_EKS_CLUSTER_SECURITY_GROUP_ID"] = "sfid"
+    os.environ["ADDF_FSX_FILE_SYSTEM_ID"] = "fsid"
+    os.environ["ADDF_FSX_SECURITY_GROUP_ID"] = "sgid"
+    os.environ["ADDF_FSX_MOUNT_NAME"] = "asdf"
+    os.environ["ADDF_FSX_DNS_NAME"] = "asfsad"
+    os.environ["ADDF_FSX_STORAGE_CAPACITY"] = "1200"
+    os.environ["EKS_NAMESPACE"] = "namespace"
+    # Unload the app import so that subsequent tests don't reuse
+    if "app" in sys.modules:
+        del sys.modules["app"]
+
+
+def test_app(stack_defaults):
+    with pytest.raises(TypeError):
+        import app  # noqa: F401
+
+
+def test_missing_namespace(stack_defaults):
+    del os.environ["EKS_NAMESPACE"]
+    with pytest.raises(ValueError):
+        import app  # noqa: F401
+
+
+def test_wrong_capacity(stack_defaults):
+    os.environ["SEEDFARMER_FSX_STORAGE_CAPACITY"] = "130"
+    with pytest.raises(TypeError):
+        import app  # noqa: F401

--- a/modules/integration/fsx-lustre-on-eks/tests/test_stack.py
+++ b/modules/integration/fsx-lustre-on-eks/tests/test_stack.py
@@ -40,6 +40,7 @@ def test_synthesize_stack(stack_defaults):
         fsx_security_group_id="sg-0123456",
         fsx_mount_name="foobar",
         fsx_dns_name="example.com",
+        fsx_storage_capacity="1200Gi",
         eks_namespace="service.example.com",
         env=cdk.Environment(
             account=os.environ["CDK_DEFAULT_ACCOUNT"],


### PR DESCRIPTION
*Issue #, if available:*
#415 
*Description of changes:*
Adding ability to pass in storage capacity on fsx-lsutre-on-eks from the manifests

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
