### PR TITLE
generify docker-build module

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - `examples/example-dags`
   - `examples/example-tf`
   - `examples/example-tf-prereqs`
+  - `examples/docker-build`
   - `sensor-extraction/ros-to-parquet`
   - `sensor-extraction/ros-to-png`
   - `post-processing/yolo-object-detection`

--- a/modules/examples/docker-build/README.md
+++ b/modules/examples/docker-build/README.md
@@ -6,4 +6,4 @@ This module demonstrates an example on how to build Docker Images from a given s
 
 ### Required Parameters
 
-- `ecr-repo-name`: ECR Repository name to be used/created if it doesnt exist.
+- `ecr-repo-name`: ECR Repository name to be used/created if it doesn't exist.

--- a/modules/examples/docker-build/deployspec.yaml
+++ b/modules/examples/docker-build/deployspec.yaml
@@ -1,11 +1,12 @@
+publishGenericEnvVariables: true
 deploy:
   phases:
     build:
       commands:
-        - aws ecr describe-repositories --repository-names ${AWS_CODESEEDER_NAME}-${ADDF_PARAMETER_ECR_REPO_NAME} || aws ecr create-repository --repository-name ${AWS_CODESEEDER_NAME}-${ADDF_PARAMETER_ECR_REPO_NAME} --image-scanning-configuration scanOnPush=true
+        - aws ecr describe-repositories --repository-names ${SEEDFARMER_PARAMETER_ECR_REPO_NAME} || aws ecr create-repository --repository-name ${SEEDFARMER_PARAMETER_ECR_REPO_NAME} --image-scanning-configuration scanOnPush=true
         - export COMMIT_HASH=$(echo $CODEBUILD_RESOLVED_SOURCE_VERSION | cut -c 1-7)
         - export IMAGE_TAG=${COMMIT_HASH:=latest}
-        - export REPOSITORY_URI=$AWS_ACCOUNT_ID.dkr.ecr.$AWS_DEFAULT_REGION.amazonaws.com/$AWS_CODESEEDER_NAME-$ADDF_PARAMETER_ECR_REPO_NAME
+        - export REPOSITORY_URI=$AWS_ACCOUNT_ID.dkr.ecr.$AWS_DEFAULT_REGION.amazonaws.com/${SEEDFARMER_PARAMETER_ECR_REPO_NAME}
         - aws ecr get-login-password --region $AWS_DEFAULT_REGION | docker login --username AWS --password-stdin $AWS_ACCOUNT_ID.dkr.ecr.$AWS_DEFAULT_REGION.amazonaws.com
         - echo Building the Docker image...
         - cd service/ && docker build -t $REPOSITORY_URI:latest .
@@ -15,5 +16,5 @@ destroy:
   phases:
     build:
       commands:
-        - aws ecr delete-repository --repository-name ${AWS_CODESEEDER_NAME}-${ADDF_PARAMETER_ECR_REPO_NAME} --force
+        - aws ecr delete-repository --repository-name ${SEEDFARMER_PARAMETER_ECR_REPO_NAME} --force
 # build_type: BUILD_GENERAL1_LARGE

--- a/modules/examples/docker-build/modulestack.yaml
+++ b/modules/examples/docker-build/modulestack.yaml
@@ -11,6 +11,9 @@ Parameters:
   RoleName:
     Type: String
     Description: The name of the IAM Role
+  ECRRepoName:
+    Type: String
+    Description: The name of the ECR repository
 
 Resources:
   Policy:
@@ -33,7 +36,7 @@ Resources:
               - "ecr:Put*"
             Effect: Allow
             Resource:
-              - !Sub "arn:aws:ecr:${AWS::Region}:${AWS::AccountId}:repository/addf-*"
+              - !Sub "arn:aws:ecr:${AWS::Region}:${AWS::AccountId}:repository/${ECRRepoName}"
         Version: 2012-10-17
-      PolicyName: "addf-modulespecific-policy"
+      PolicyName: "modulespecific-policy"
       Roles: [!Ref RoleName]


### PR DESCRIPTION
*Description of changes:*
Refactoring `docker-build` module to be generic. 

NOTE: the only change from the original behaviour is ECR repository name used to be prefixed with seedkit name. I do not think this is required, but can change back to adhere to the same behaviour.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
