### PR TITLE
chore: update workflow to only run once a day

### DIFF
--- a/.github/workflows/check-integration-tests.yml
+++ b/.github/workflows/check-integration-tests.yml
@@ -3,7 +3,7 @@ name: Check Modules for Integration Tests
 on:
   workflow_dispatch:
   schedule:
-    - cron: "0 */3 * * *"
+    - cron: "0 1 * * *"
 
 jobs:
   get-modules:


### PR DESCRIPTION
## Description of changes
- update workflow to only run once a day to avoid intermittent rate limit issues with our other repos


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
