### PR TITLE
chore: update ros-image-demo manifests to use latest ecr module

### DIFF
--- a/manifests/ros-image-demo/ros-image-demo-mwaa/docker-repository-modules.yaml
+++ b/manifests/ros-image-demo/ros-image-demo-mwaa/docker-repository-modules.yaml
@@ -1,5 +1,5 @@
 name: ros-to-parquet
-path: git::https://github.com/awslabs/idf-modules.git//modules/storage/ecr?ref=release/1.7.0
+path: git::https://github.com/awslabs/idf-modules.git//modules/storage/ecr?ref=release/1.11.0
 parameters:
   - name: image-tag-mutability
     value: "MUTABLE"
@@ -7,7 +7,7 @@ parameters:
     value: "DESTROY"
 ---
 name: ros-to-png
-path: git::https://github.com/awslabs/idf-modules.git//modules/storage/ecr?ref=release/1.7.0
+path: git::https://github.com/awslabs/idf-modules.git//modules/storage/ecr?ref=release/1.11.0
 parameters:
   - name: image-tag-mutability
     value: "MUTABLE"
@@ -15,7 +15,7 @@ parameters:
     value: "DESTROY"
 ---
 name: object-detection
-path: git::https://github.com/awslabs/idf-modules.git//modules/storage/ecr?ref=release/1.7.0
+path: git::https://github.com/awslabs/idf-modules.git//modules/storage/ecr?ref=release/1.11.0
 parameters:
   - name: image-tag-mutability
     value: "MUTABLE"
@@ -23,7 +23,7 @@ parameters:
     value: "DESTROY"
 ---
 name: lane-detection
-path: git::https://github.com/awslabs/idf-modules.git//modules/storage/ecr?ref=release/1.7.0
+path: git::https://github.com/awslabs/idf-modules.git//modules/storage/ecr?ref=release/1.11.0
 parameters:
   - name: image-tag-mutability
     value: "MUTABLE"

--- a/manifests/ros-image-demo/ros-image-demo-sfn/docker-repository-modules.yaml
+++ b/manifests/ros-image-demo/ros-image-demo-sfn/docker-repository-modules.yaml
@@ -1,5 +1,5 @@
 name: ros-to-parquet
-path: git::https://github.com/awslabs/idf-modules.git//modules/storage/ecr?ref=release/1.7.0
+path: git::https://github.com/awslabs/idf-modules.git//modules/storage/ecr?ref=release/1.11.0
 parameters:
   - name: image-tag-mutability
     value: "MUTABLE"
@@ -7,7 +7,7 @@ parameters:
     value: "DESTROY"
 ---
 name: ros-to-png
-path: git::https://github.com/awslabs/idf-modules.git//modules/storage/ecr?ref=release/1.7.0
+path: git::https://github.com/awslabs/idf-modules.git//modules/storage/ecr?ref=release/1.11.0
 parameters:
   - name: image-tag-mutability
     value: "MUTABLE"
@@ -15,7 +15,7 @@ parameters:
     value: "DESTROY"
 ---
 name: object-detection
-path: git::https://github.com/awslabs/idf-modules.git//modules/storage/ecr?ref=release/1.7.0
+path: git::https://github.com/awslabs/idf-modules.git//modules/storage/ecr?ref=release/1.11.0
 parameters:
   - name: image-tag-mutability
     value: "MUTABLE"
@@ -23,7 +23,7 @@ parameters:
     value: "DESTROY"
 ---
 name: lane-detection
-path: git::https://github.com/awslabs/idf-modules.git//modules/storage/ecr?ref=release/1.7.0
+path: git::https://github.com/awslabs/idf-modules.git//modules/storage/ecr?ref=release/1.11.0
 parameters:
   - name: image-tag-mutability
     value: "MUTABLE"


### PR DESCRIPTION
### Changes
- update ros-image-demo manifests to use latest ecr module


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
