### PR TITLE
chore: fix `robotic-training-on-eks` manifest module reference

### DIFF
--- a/manifests/robotic-training-on-eks/dcv-eks.yaml
+++ b/manifests/robotic-training-on-eks/dcv-eks.yaml
@@ -1,5 +1,5 @@
 name: dcv-eks
-path: modules/visualization/dcv-eks
+path: git::https://github.com/awslabs/autonomous-driving-data-framework.git//modules/visualization/dcv-eks?ref=release/3.6.0&depth=1
 parameters:
   - name: dcv-namespace
     value: dcv


### PR DESCRIPTION
### Changes 
- fix robotic-training-on-eks manifest module reference


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
