### PR TITLE
fix deployspec export of metadata in rosbag-sfn

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - pin github action to hash instead of explicit version
 - update to yolo11 object detection model
 - fix `opensearch-tunnel` user data install script
+- fix `analysis/rosbag-image-pipeline-sfn` to properly record metadata
 
 ### **Removed**
 

--- a/manifests/ros-image-demo/ros-image-demo-sfn/aws-analysis-modules.yaml
+++ b/manifests/ros-image-demo/ros-image-demo-sfn/aws-analysis-modules.yaml
@@ -1,5 +1,5 @@
 name: rip
-path: modules/analysis/rosbag-image-pipeline-sfn
+path: git::https://github.com/awslabs/autonomous-driving-data-framework.git//modules/analysis/rosbag-image-pipeline-sfn/?ref=release/3.7.1
 parameters:
   - name: vpc-id
     valueFrom:

--- a/modules/analysis/rosbag-image-pipeline-sfn/deployspec.yaml
+++ b/modules/analysis/rosbag-image-pipeline-sfn/deployspec.yaml
@@ -9,7 +9,7 @@ deploy:
       commands:
       - cdk deploy --require-approval never --progress events --app "python app.py" --outputs-file ./cdk-exports.json
       # Here we export some env vars
-      - export SEEDFARMER_MODULE_METADATA=$(python -c "import json; file=open('cdk-exports.json'); print(json.load(file)['addf-${SEEDFARMER_DEPLOYMENT_NAME}-${SEEDFARMER_MODULE_NAME}']['metadata'])") || true
+      - seedfarmer metadata convert -f cdk-exports.json || true
       - export EMR_DIR="emr-scripts"
       - wget -O $EMR_DIR/spark-dynamodb_2.12-1.1.1.jar https://repo1.maven.org/maven2/com/audienceproject/spark-dynamodb_2.12/1.1.1/spark-dynamodb_2.12-1.1.1.jar
       - aws s3 cp --recursive $EMR_DIR/ s3://$SEEDFARMER_PARAMETER_ARTIFACTS_BUCKET_NAME/$EMR_DIR/


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Corrected the export of metadata in `autonomous-driving-data-framework/modules/analysis/rosbag-image-pipeline-sfn`

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
